### PR TITLE
Feat/update instantsearch css

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@angular/core": "^4.4.5",
     "algoliasearch": "^3.24.7",
     "algoliasearch-helper": "^2.23.0",
-    "instantsearch.css": "^6.0.1",
+    "instantsearch.css": "^7.0.0",
     "instantsearch.js": "^2.3.1",
     "lodash-es": "^4.17.4",
     "nouislider": "^10.0.0",

--- a/src/current-refinements/__tests__/__snapshots__/current-refinements.spec.ts.snap
+++ b/src/current-refinements/__tests__/__snapshots__/current-refinements.spec.ts.snap
@@ -21,154 +21,156 @@ exports[`CurrentRefinedValues renders markup with state 1`] = `
         
   
         
+        
         <ul
           class="ais-CurrentRefinements-list"
         >
           
           
-          
           <li
             class="ais-CurrentRefinements-item"
           >
             
             
-            <button
-              class="ais-CurrentRefinements-button"
+            <span
+              class="ais-CurrentRefinements-label"
+            >
+              Brand:
+            </span>
+            
+  
+            
+            
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
                 Canon
               </span>
               
               
-              
-              <span
-                class="ais-CurrentRefinements-count"
-              >
-                
-                27
-              
-              </span>
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
-            
-          
-          </li>
-          <li
-            class="ais-CurrentRefinements-item"
-          >
-            
-            
-            <button
-              class="ais-CurrentRefinements-button"
+            </span>
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
                 Sony
               </span>
               
               
-              
-              <span
-                class="ais-CurrentRefinements-count"
-              >
-                
-                28
-              
-              </span>
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
+            </span>
             
           
           </li>
+          
+        
+        </ul>
+        <ul
+          class="ais-CurrentRefinements-list"
+        >
+          
+          
           <li
             class="ais-CurrentRefinements-item"
           >
             
             
-            <button
-              class="ais-CurrentRefinements-button"
+            <span
+              class="ais-CurrentRefinements-label"
+            >
+              Hierarchicalcategories.lvl0:
+            </span>
+            
+  
+            
+            
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
                 Cameras & Camcorders
               </span>
               
               
-              
-              <span
-                class="ais-CurrentRefinements-count"
-              >
-                
-                55
-              
-              </span>
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
+            </span>
             
           
           </li>
+          
+        
+        </ul>
+        <ul
+          class="ais-CurrentRefinements-list"
+        >
+          
+          
           <li
             class="ais-CurrentRefinements-item"
           >
             
             
-            <button
-              class="ais-CurrentRefinements-button"
+            <span
+              class="ais-CurrentRefinements-label"
+            >
+              Popularity:
+            </span>
+            
+  
+            
+            
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
-                ≥ 0
+                0
               </span>
               
               
-              
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
+            </span>
             
           
           </li>
@@ -220,15 +222,7 @@ exports[`CurrentRefinedValues renders markup without state 1`] = `
         
   
         
-        <ul
-          class="ais-CurrentRefinements-list"
-        >
-          
-          
-          
-          
         
-        </ul>
         
   
         
@@ -274,154 +268,156 @@ exports[`CurrentRefinedValues should apply \`transformItems\` if specified 1`] =
         
   
         
+        
         <ul
           class="ais-CurrentRefinements-list"
         >
           
           
-          
           <li
             class="ais-CurrentRefinements-item"
           >
             
             
-            <button
-              class="ais-CurrentRefinements-button"
+            <span
+              class="ais-CurrentRefinements-label"
+            >
+              Brand:
+            </span>
+            
+  
+            
+            
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
-                foo - Canon
+                Canon
               </span>
               
               
-              
-              <span
-                class="ais-CurrentRefinements-count"
-              >
-                
-                27
-              
-              </span>
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
-            
-          
-          </li>
-          <li
-            class="ais-CurrentRefinements-item"
-          >
-            
-            
-            <button
-              class="ais-CurrentRefinements-button"
+            </span>
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
-                foo - Sony
+                Sony
               </span>
               
               
-              
-              <span
-                class="ais-CurrentRefinements-count"
-              >
-                
-                28
-              
-              </span>
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
+            </span>
             
           
           </li>
+          
+        
+        </ul>
+        <ul
+          class="ais-CurrentRefinements-list"
+        >
+          
+          
           <li
             class="ais-CurrentRefinements-item"
           >
             
             
-            <button
-              class="ais-CurrentRefinements-button"
+            <span
+              class="ais-CurrentRefinements-label"
+            >
+              Hierarchicalcategories.lvl0:
+            </span>
+            
+  
+            
+            
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
-                foo - Cameras & Camcorders
+                Cameras & Camcorders
               </span>
               
               
-              
-              <span
-                class="ais-CurrentRefinements-count"
-              >
-                
-                55
-              
-              </span>
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
+            </span>
             
           
           </li>
+          
+        
+        </ul>
+        <ul
+          class="ais-CurrentRefinements-list"
+        >
+          
+          
           <li
             class="ais-CurrentRefinements-item"
           >
             
             
-            <button
-              class="ais-CurrentRefinements-button"
+            <span
+              class="ais-CurrentRefinements-label"
+            >
+              Popularity:
+            </span>
+            
+  
+            
+            
+            <span
+              class="ais-CurrentRefinements-category"
             >
               
               
               <span
-                class="ais-CurrentRefinements-label"
+                class="ais-CurrentRefinements-categoryLabel"
               >
-                foo - ≥ 0
+                0
               </span>
               
               
-              
-              
-              
-              <span
+              <button
                 class="ais-CurrentRefinements-delete"
               >
                 ✕
-              </span>
+              </button>
               
             
-            </button>
+            </span>
             
           
           </li>

--- a/src/current-refinements/__tests__/current-refinements.spec.ts
+++ b/src/current-refinements/__tests__/current-refinements.spec.ts
@@ -67,7 +67,9 @@ describe("CurrentRefinedValues", () => {
     const refine = jest.fn();
     const fixture = render({ refine });
 
-    const [firstEl] = fixture.debugElement.nativeElement.querySelectorAll("li");
+    const [firstEl] = fixture.debugElement.nativeElement.querySelectorAll(
+      "span > button"
+    );
     firstEl.click();
 
     expect(refine).toHaveBeenCalled();

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,8 +107,8 @@
     to-fast-properties "^2.0.0"
 
 "@ngtools/webpack@^1.7.4":
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-1.9.5.tgz#10292e9237d1218fe16dee24423155500b2d2324"
+  version "1.9.6"
+  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-1.9.6.tgz#102c60ee4b8a84a26ddc1e2b334f327e91821a4d"
   dependencies:
     chalk "~2.2.0"
     enhanced-resolve "^3.1.0"
@@ -124,8 +124,8 @@
   resolved "https://registry.yarnpkg.com/@types/inline-style-prefixer/-/inline-style-prefixer-3.0.1.tgz#8541e636b029124b747952e9a28848286d2b5bf6"
 
 "@types/jest@^22.0.0":
-  version "22.1.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.1.0.tgz#c1de03bbac66fac4cc741f7a69cb73bc01a1707c"
+  version "22.1.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.1.1.tgz#231d7c60ed130200af9e96c82469ed25b59a7ea2"
 
 "@types/lodash-es@^4.17.0":
   version "4.17.0"
@@ -134,12 +134,12 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.96"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.96.tgz#49a402bb6984af7dd9a48cea3781744a3774bff1"
+  version "4.14.98"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.98.tgz#aaf012ae443e657e7885e605a4c1b340db160609"
 
 "@types/node@^9.3.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.3.0.tgz#3a129cda7c4e5df2409702626892cb4b96546dd5"
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.0.tgz#b85a0bcf1e1cc84eb4901b7e96966aedc6f078d1"
 
 "@types/nouislider@^9.0.3":
   version "9.0.4"
@@ -1598,8 +1598,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000795"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000795.tgz#644f03fab00dd8bd1693e5e1e70d86b31c5cfece"
+  version "1.0.30000799"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000799.tgz#0904953de93f3f492647e58c1a1bda7a73a0cb0b"
 
 caniuse-lite@^1.0.30000792:
   version "1.0.30000792"
@@ -1902,46 +1902,46 @@ content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
-conventional-changelog-angular@^1.5.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.0.tgz#0a26a071f2c9fcfcf2b86ba0cfbf6e6301b75bfa"
+conventional-changelog-angular@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-1.6.1.tgz#e1434d017c854032b272f690424a8c0ca16dc318"
   dependencies:
     compare-func "^1.3.1"
     q "^1.4.1"
 
-conventional-changelog-atom@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-0.1.2.tgz#12595ad5267a6937c34cf900281b1c65198a4c63"
+conventional-changelog-atom@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-atom/-/conventional-changelog-atom-0.2.0.tgz#72f18e5c74e3d8807411252fe013818ddffa7157"
   dependencies:
     q "^1.4.1"
 
 conventional-changelog-cli@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-cli/-/conventional-changelog-cli-1.3.5.tgz#46c51496216b7406588883defa6fac589e9bb31e"
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-cli/-/conventional-changelog-cli-1.3.8.tgz#3b3f3591cb8d1f154bdb28e1819c5fcd8d967536"
   dependencies:
     add-stream "^1.0.0"
-    conventional-changelog "^1.1.7"
+    conventional-changelog "^1.1.10"
     lodash "^4.1.0"
     meow "^3.7.0"
     tempfile "^1.1.1"
 
-conventional-changelog-codemirror@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.1.tgz#299a4f7147baf350e6c8158fc54954a291c5cc09"
+conventional-changelog-codemirror@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.3.0.tgz#4dd8abb9f521a638cab49f683496c26b8a5c6d31"
   dependencies:
     q "^1.4.1"
 
-conventional-changelog-core@^1.9.3:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-1.9.5.tgz#5db7566dad7c0cb75daf47fbb2976f7bf9928c1d"
+conventional-changelog-core@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-2.0.0.tgz#1bdf7d21f3d066427ff9e07db0a2c5dd60015b9f"
   dependencies:
-    conventional-changelog-writer "^2.0.3"
+    conventional-changelog-writer "^3.0.0"
     conventional-commits-parser "^2.1.0"
     dateformat "^1.0.12"
     get-pkg-repo "^1.0.0"
     git-raw-commits "^1.3.0"
     git-remote-origin-url "^2.0.0"
-    git-semver-tags "^1.2.3"
+    git-semver-tags "^1.3.0"
     lodash "^4.0.0"
     normalize-package-data "^2.3.5"
     q "^1.4.1"
@@ -1949,21 +1949,21 @@ conventional-changelog-core@^1.9.3:
     read-pkg-up "^1.0.1"
     through2 "^2.0.0"
 
-conventional-changelog-ember@^0.2.9:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.2.10.tgz#dcd6e4cdc2e6c2b58653cf4d2cb1656a60421929"
+conventional-changelog-ember@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-ember/-/conventional-changelog-ember-0.3.1.tgz#bc71dc0a57e5c7ed0bf0538c32e44220691871d1"
   dependencies:
     q "^1.4.1"
 
-conventional-changelog-eslint@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.1.tgz#2c2a11beb216f80649ba72834180293b687c0662"
+conventional-changelog-eslint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-eslint/-/conventional-changelog-eslint-1.0.0.tgz#c63cd9d6f09d4e204530ae7369d7a20a167bc6bc"
   dependencies:
     q "^1.4.1"
 
-conventional-changelog-express@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-0.2.1.tgz#838d9e1e6c9099703b150b9c19aa2d781742bd6c"
+conventional-changelog-express@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-express/-/conventional-changelog-express-0.3.0.tgz#5ed006f48682d8615ee0ab5f53cacb26fbd3e1c8"
   dependencies:
     q "^1.4.1"
 
@@ -1979,16 +1979,16 @@ conventional-changelog-jscs@^0.1.0:
   dependencies:
     q "^1.4.1"
 
-conventional-changelog-jshint@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.1.tgz#86139bb3ac99899f2b177e9617e09b37d99bcf3a"
+conventional-changelog-jshint@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-jshint/-/conventional-changelog-jshint-0.3.0.tgz#0393fd468113baf73cba911d17c5826423366a28"
   dependencies:
     compare-func "^1.3.1"
     q "^1.4.1"
 
-conventional-changelog-writer@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-2.0.3.tgz#073b0c39f1cc8fc0fd9b1566e93833f51489c81c"
+conventional-changelog-writer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-3.0.0.tgz#e106154ed94341e387d717b61be2181ff53254cc"
   dependencies:
     compare-func "^1.3.1"
     conventional-commits-filter "^1.1.1"
@@ -2001,20 +2001,20 @@ conventional-changelog-writer@^2.0.3:
     split "^1.0.0"
     through2 "^2.0.0"
 
-conventional-changelog@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.1.7.tgz#9151a62b1d8edb2d82711dabf5b7cf71041f82b1"
+conventional-changelog@^1.1.10:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/conventional-changelog/-/conventional-changelog-1.1.10.tgz#d9bb3aad9086152d283e4707fb45a5b7a28e9e98"
   dependencies:
-    conventional-changelog-angular "^1.5.2"
-    conventional-changelog-atom "^0.1.2"
-    conventional-changelog-codemirror "^0.2.1"
-    conventional-changelog-core "^1.9.3"
-    conventional-changelog-ember "^0.2.9"
-    conventional-changelog-eslint "^0.2.1"
-    conventional-changelog-express "^0.2.1"
+    conventional-changelog-angular "^1.6.1"
+    conventional-changelog-atom "^0.2.0"
+    conventional-changelog-codemirror "^0.3.0"
+    conventional-changelog-core "^2.0.0"
+    conventional-changelog-ember "^0.3.1"
+    conventional-changelog-eslint "^1.0.0"
+    conventional-changelog-express "^0.3.0"
     conventional-changelog-jquery "^0.1.0"
     conventional-changelog-jscs "^0.1.0"
-    conventional-changelog-jshint "^0.2.1"
+    conventional-changelog-jshint "^0.3.0"
 
 conventional-commits-filter@^1.1.1:
   version "1.1.1"
@@ -2470,7 +2470,7 @@ dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
 
-dns-packet@^1.0.1:
+dns-packet@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
   dependencies:
@@ -2521,8 +2521,8 @@ dom-walk@^0.1.0:
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
 
 domain-browser@^1.1.1:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
 
 domelementtype@1:
   version "1.3.0"
@@ -3364,9 +3364,9 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.2.3.tgz#188b453882bf9d7a23afd31baba537dab7388d5d"
+git-semver-tags@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-1.3.0.tgz#b154833a6ab5c360c0ad3b1aa9b8f12ea06de919"
   dependencies:
     meow "^3.3.0"
     semver "^5.0.1"
@@ -3422,8 +3422,8 @@ global@^4.3.2:
     process "~0.5.1"
 
 globals@^11.0.1, globals@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -3844,9 +3844,9 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-instantsearch.css@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-6.0.1.tgz#00063ba3653c5c78772e35a7eb084acd9b6b5cd4"
+instantsearch.css@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.0.0.tgz#74fb9aa25ce64c80effc663fe92bc9ec785cc5e3"
 
 instantsearch.js@^2.3.1:
   version "2.4.1"
@@ -4512,8 +4512,8 @@ jest@^22.1.4:
     jest-cli "^22.1.4"
 
 js-base64@^2.1.9:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.2.tgz#1896da010ef8862f385d8887648e9b6dc4a7a2e9"
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -4538,8 +4538,8 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
 jsdom@^11.5.1:
-  version "11.6.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.1.tgz#43fffc10072597a8ee9680cba46900d9e4dbeba2"
+  version "11.6.2"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.6.2.tgz#25d1ef332d48adf77fc5221fe2619967923f16bb"
   dependencies:
     abab "^1.0.4"
     acorn "^5.3.0"
@@ -4554,7 +4554,7 @@ jsdom@^11.5.1:
     html-encoding-sniffer "^1.0.2"
     left-pad "^1.2.0"
     nwmatcher "^1.4.3"
-    parse5 "^4.0.0"
+    parse5 "4.0.0"
     pn "^1.1.0"
     request "^2.83.0"
     request-promise-native "^1.0.5"
@@ -5048,11 +5048,11 @@ multicast-dns-service-types@^1.1.0:
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
 
 multicast-dns@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.2.tgz#300b6133361f8aaaf2b8d1248e85c363fe5b95a0"
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-6.2.3.tgz#a0ec7bd9055c4282f790c3c82f4e28db3b31b229"
   dependencies:
-    dns-packet "^1.0.1"
-    thunky "^0.1.0"
+    dns-packet "^1.3.1"
+    thunky "^1.0.2"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -5105,9 +5105,9 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-forge@0.6.33:
-  version "0.6.33"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.6.33.tgz#463811879f573d45155ad6a9f43dc296e8e85ebc"
+node-forge@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5459,7 +5459,7 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse5@^4.0.0:
+parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
 
@@ -6485,10 +6485,10 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
 selfsigned@^1.9.1:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.1.tgz#bf8cb7b83256c4551e31347c6311778db99eec52"
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.2.tgz#b4449580d99929b65b10a48389301a6592088758"
   dependencies:
-    node-forge "0.6.33"
+    node-forge "0.7.1"
 
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
@@ -6705,8 +6705,8 @@ source-map-support@^0.4.15, source-map-support@^0.4.2:
     source-map "^0.5.6"
 
 source-map-support@^0.5.0:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.2.tgz#1a6297fd5b2e762b39688c7fc91233b60984f0a5"
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
   dependencies:
     source-map "^0.6.0"
 
@@ -7073,9 +7073,9 @@ through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-thunky@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/thunky/-/thunky-0.1.0.tgz#bf30146824e2b6e67b0f2d7a4ac8beb26908684e"
+thunky@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.0.2.tgz#a862e018e3fb1ea2ec3fce5d55605cf57f247371"
 
 time-stamp@^2.0.0:
   version "2.0.0"
@@ -7167,8 +7167,8 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 ts-jest@^22.0.0:
-  version "22.0.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-22.0.1.tgz#48942936a466c2e76e259b02e2f1356f1839afc3"
+  version "22.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-22.0.2.tgz#d83eb2e3a2a4f3be098afea5a06d38547d528c72"
   dependencies:
     babel-core "^6.24.1"
     babel-plugin-istanbul "^4.1.4"
@@ -7179,7 +7179,7 @@ ts-jest@^22.0.0:
     jest-config "^22.0.1"
     pkg-dir "^2.0.0"
     source-map-support "^0.5.0"
-    yargs "^10.0.3"
+    yargs "^11.0.0"
 
 ts-loader@^2.0.0:
   version "2.3.7"
@@ -7310,8 +7310,8 @@ ua-parser-js@^0.7.9:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
 
 uglify-js@3.3.x:
-  version "3.3.8"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.8.tgz#51e9a5db73afb53ac98603d08224edcd0be45fd8"
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.9.tgz#33869666c8ab7f7658ce3d22f0f1ced40097d33a"
   dependencies:
     commander "~2.13.0"
     source-map "~0.6.1"
@@ -7753,6 +7753,12 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
@@ -7787,6 +7793,23 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
* Group Current Refinements items by attributeName & refinement type
* Enhance display of numeric refined items

I would love to have @samouss thoughts on how I did this, could not find where do you compute this data into React-InstantSearch (https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch/src/connectors/connectCurrentRefinements.js#L13)