### PR TITLE
Update: 'Getting Started' guide refinement widgets

### DIFF
--- a/community-website/src/community-project-boilerplate-docgen/src/getting-started.md
+++ b/community-website/src/community-project-boilerplate-docgen/src/getting-started.md
@@ -236,7 +236,7 @@ We now miss two elements in our search interface:
 * The ability to browse beyond the first page of results
 * The ability to reset the filters
 
-Those two features are implemented respectively with the [Pagination](widgets/pagination.html), [ClearRefinements](clear-refinements.html) and [CurrentRefinements](widgets/current-refinements.html) widgets. They all have nice defaults which means that we can use them directly without further configuration.
+Those two features are implemented respectively with the [Pagination](widgets/pagination.html), [ClearRefinements](widgets/clear-refinements.html) and [CurrentRefinements](widgets/current-refinements.html) widgets. They all have nice defaults which means that we can use them directly without further configuration.
 
 ```html
 <ng-ais-instantsearch [config]="{...}">

--- a/community-website/src/community-project-boilerplate-docgen/src/getting-started.md
+++ b/community-website/src/community-project-boilerplate-docgen/src/getting-started.md
@@ -236,7 +236,7 @@ We now miss two elements in our search interface:
 * The ability to browse beyond the first page of results
 * The ability to reset the filters
 
-Those two features are implemented respectively with the [Pagination](widgets/pagination.html), [ClearAll](widgets/clear-all.html) and [CurrentRefinedValues](widgets/current-refined-values.html) widgets. They all have nice defaults which means that we can use them directly without further configuration.
+Those two features are implemented respectively with the [Pagination](widgets/pagination.html), [ClearRefinements](clear-refinements.html) and [CurrentRefinements](widgets/current-refinements.html) widgets. They all have nice defaults which means that we can use them directly without further configuration.
 
 ```html
 <ng-ais-instantsearch [config]="{...}">
@@ -247,17 +247,17 @@ Those two features are implemented respectively with the [Pagination](widgets/pa
   <ng-ais-refinement-list attribute="category">
   </ng-ais-refinement-list>
 
-  <!-- CurrentRefinedValues -->
-  <ng-ais-current-refined-values [clearAll]="false">
+  <!-- CurrentRefinements -->
+  <ng-ais-current-refinements [clearRefinements]="false">
     <!--
-      This widget can also contain a clear all link to remove all filters,
-      we disable it in this example since we use `clearAll` widget on its own.
+      This widget can also contain a clear refinements link to remove all filters,
+      we disable it in this example since we use `ClearRefinements` widget on its own.
     -->
-  </ng-ais-current-refined-values>
+  </ng-ais-current-refinements>
 
-  <!-- ClearAll -->
-  <ng-ais-clear-all clearAllLabel="Reset everything">
-  </ng-ais-clear-all>
+  <!-- ClearRefinements -->
+  <ng-ais-clear-refinements buttonLabel="Reset everything">
+  </ng-ais-clear-refinements>
 
   <!-- Hits -->
   <ng-ais-hits></ng-ais-hits>


### PR DESCRIPTION
Hello! In using the getting started guide, I came across these changes to the components in the repo which are not reflected in the guide:
- Update widget reference from `CurrentRefinedValues` to `CurrentRefinements` including links to [docs](https://community.algolia.com/angular-instantsearch/widgets/current-refinements.html)
- Update widget reference from `ClearAll` to `ClearRefinements` including links to [docs](https://community.algolia.com/angular-instantsearch/widgets/clear-refinements.html)