### PR TITLE
docs(InfiniteHits): show usage with the button

### DIFF
--- a/community-website/src/community-project-boilerplate-docgen/src/widgets/infinite-hits.md
+++ b/community-website/src/community-project-boilerplate-docgen/src/widgets/infinite-hits.md
@@ -24,6 +24,7 @@ You can use the directive `<ng-template></ng-template>` to customize the output.
   <ng-template
     let-hits="hits"
     let-results="results"
+    let-refine="showMore"
   >
     <!-- No results message -->
     <div *ngIf="hits.length === 0">
@@ -42,6 +43,11 @@ You can use the directive `<ng-template></ng-template>` to customize the output.
 
       <p>{{hit.description}}</p>
     </div>
+
+    <!-- Show more button template -->
+    <button (click)="refine($event)">
+      Show more
+    </button>
   </ng-template>
 </ais-infinite-hits>
 ```


### PR DESCRIPTION
**Summary**

closes #126 

In the current documentation of `<ais-infinite-hits></ais-infinite-hits>` we don't implement the show more button. It might be a bit confusing for the user because there is no way to load more pages.

**Results**

https://codesandbox.io/s/8y9lzxv192