### PR TITLE
docs(theme): reset is included in theme

### DIFF
--- a/examples/angular-router/src/styles.scss
+++ b/examples/angular-router/src/styles.scss
@@ -1,5 +1,4 @@
 @charset 'utf-8';
-@import '~angular-instantsearch/bundles/instantsearch.css';
 @import '~angular-instantsearch/bundles/instantsearch-theme-algolia.css';
 
 body {

--- a/examples/media/src/styles.scss
+++ b/examples/media/src/styles.scss
@@ -1,5 +1,4 @@
 @charset 'utf-8';
-@import '~angular-instantsearch/bundles/instantsearch.css';
 @import '~angular-instantsearch/bundles/instantsearch-theme-algolia.css';
 
 $white: #FFFFFF;

--- a/examples/server-side-rendering/src/styles.scss
+++ b/examples/server-side-rendering/src/styles.scss
@@ -1,3 +1,2 @@
 /* You can add global styles to this file, and also import other style files */
-@import '~angular-instantsearch/bundles/instantsearch.css';
 @import '~angular-instantsearch/bundles/instantsearch-theme-algolia.css';

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -24,10 +24,7 @@ module.exports = {
   entry: {
     polyfills: './examples/dev-novel/polyfill.ts',
     main: './examples/dev-novel/main.ts',
-    styles: [
-      './node_modules/instantsearch.css/themes/reset.css',
-      './node_modules/instantsearch.css/themes/algolia.css',
-    ],
+    styles: ['./node_modules/instantsearch.css/themes/algolia.css'],
   },
 
   output: {


### PR DESCRIPTION
There's no need to include instantsearch.css because it's already
included in instantsearch.css algolia theme.

Let's wait for the build and see how it goes.