### PR TITLE
chore(release): fix release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     ],
     "packageRules": [
       {
-        "paths": ["community-website"],
+        "paths": [
+          "community-website"
+        ],
         "extends": [
           "config:js-app",
           "algolia"
@@ -124,7 +126,9 @@
     "prettier": "^1.13.5",
     "raw-loader": "^0.5.1",
     "readline-sync": "^1.4.9",
+    "replace-in-file": "3.4.0",
     "rxjs": "^5.4.3",
+    "semver": "5.5.0",
     "shelljs": "^0.8.1",
     "style-loader": "^0.21.0",
     "ts-loader": "^2.0.1",

--- a/scripts/bump-package-version.js
+++ b/scripts/bump-package-version.js
@@ -1,0 +1,48 @@
+/* eslint no-console:0 max-len:0 */
+/* eslint-disable import/no-commonjs */
+const fs = require('fs');
+const path = require('path');
+const replace = require('replace-in-file');
+const semver = require('semver');
+const { version: currentVersion } = require('../package.json');
+
+if (!process.env.VERSION) {
+  throw new Error(
+    'bump: Usage is VERSION=MAJOR.MINOR.PATCH scripts/bump-package-version.js'
+  );
+}
+const newVersion = process.env.VERSION;
+
+if (!semver.valid(newVersion)) {
+  throw new Error(
+    `bump: Provided new version ${newVersion} is not a valid version per semver`
+  );
+}
+
+if (semver.gte(currentVersion, newVersion)) {
+  throw new Error(
+    `bump: Provided new version is not higher than current version (${newVersion} <= ${currentVersion})`
+  );
+}
+
+console.log(`Bumping ${newVersion}`);
+
+console.log('..Updating src/version.ts');
+
+const versionFile = path.join(__dirname, '../src/version.ts');
+const newContent = `export const VERSION = "${newVersion}";\n`;
+fs.writeFileSync(versionFile, newContent);
+
+console.log('..Updating package.json');
+
+replace.sync({
+  files: [path.join(__dirname, '..', 'package.json')],
+  from: `"version": "${currentVersion}"`,
+  to: `"version": "${newVersion}"`,
+});
+
+replace.sync({
+  files: [path.join(__dirname, '..', 'dist', 'package.json')],
+  from: `"version": "${currentVersion}"`,
+  to: `"version": "${newVersion}"`,
+});

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -135,12 +135,7 @@ shell.echo('');
 shell.echo(`Bumping version to "${newVersion}"`.blue);
 
 //  replace package.json with next version
-shell.exec(`sed -i.bak "s/${currVersion}/${newVersion}/g" src/version.ts`);
-shell.exec(`sed -i.bak "s/${currVersion}/${newVersion}/g" dist/package.json`);
-shell.exec(`sed -i.bak "s/${currVersion}/${newVersion}/g" package.json`);
-
-// remove .bak files from sed
-shell.exec('rm -f package.json.bak dist/package.json.bak src/version.ts.bak');
+shell.exec(`VERSION=${newVersion} node bump-package-version.js`);
 
 // install dependencies
 shell.echo('');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,7 +1775,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -7043,6 +7043,14 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+replace-in-file@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-3.4.0.tgz#b48c94567bbf4f44a2bc6fabdf21ab443e806851"
+  dependencies:
+    chalk "^2.3.2"
+    glob "^7.1.2"
+    yargs "^11.0.0"
+
 request-promise-core@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
@@ -7373,7 +7381,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@5.5.0, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 


### PR DESCRIPTION
Before this commit, replacements were done in a way that searched the
whole package.json for 2.0.1 and replaced it with 2.0.2.

This is not safe since we are sometime replacing versions of other
packages.

I reused a modified file from other projects (places) to handle this
case.