### PR TITLE
fix(docs): revert uglifyjs-webpack-plugin to 1.2.5

### DIFF
--- a/community-website/src/community-project-boilerplate-docgen/webpack.config.build.js
+++ b/community-website/src/community-project-boilerplate-docgen/webpack.config.build.js
@@ -14,6 +14,12 @@ module.exports = {
   plugins: [
     new UglifyJsPlugin({
       sourceMap: true,
+      // The version 1.2.7 of uglifyjs-webpack-plugin changed the default option
+      // to compress: { inline: 1 } but it breaks the application. Revert the previous
+      // default value did the trick.
+      uglifyOptions: {
+        compress: true,
+      },
     }),
     ...webpackConfig.plugins,
   ],


### PR DESCRIPTION
I tested it locally with this version of UglifyJS I don't have the issue. Let see if it works in the preview!