### PR TITLE
docs(stats): Fixing code example's wrong variable name

### DIFF
--- a/community-website/src/community-project-boilerplate-docgen/src/widgets/stats.md
+++ b/community-website/src/community-project-boilerplate-docgen/src/widgets/stats.md
@@ -19,7 +19,7 @@ You can use the directive `<ng-template></ng-template>` to customize the output:
   template: `
     <ais-stats>
       <ng-template let-state="state">
-        {{stats.nbHits}} results found in {{stats.processingTimeMS}}ms.
+        {{state.nbHits}} results found in {{state.processingTimeMS}}ms.
       </ng-template>
     </ais-stats>
   `


### PR DESCRIPTION
Found typo in stats widget doc