### PR TITLE
fix(instantSearch) : `searchFunction` param typing

### DIFF
--- a/community-website/src/community-project-boilerplate-docgen/src/widgets/instantsearch.md
+++ b/community-website/src/community-project-boilerplate-docgen/src/widgets/instantsearch.md
@@ -56,7 +56,7 @@ export class AppComponent {}
 `numberLocale?: string`
 > The locale used to display numbers. This will be passed to `Number.prototype.toLocaleString()`
 
-`searchFunction?: Function`
+`searchFunction?: (helper: AlgoliaSearchHelper) => void`
 > A hook that will be called each time a search needs to be done, with the helper as a parameter. It’s your responsibility to call `helper.search()`. This option allows you to avoid doing searches at page load for example.
 
 `createAlgoliaClient?: (algoliasearch: Function, appId: string, apiKey: string) => CustomClient`

--- a/src/instantsearch/instantsearch.ts
+++ b/src/instantsearch/instantsearch.ts
@@ -13,6 +13,7 @@ import { isPlatformBrowser } from "@angular/common";
 
 import * as algoliasearchProxy from "algoliasearch/lite";
 import instantsearch from "instantsearch.js/es";
+import { AlgoliaSearchHelper } from "algoliasearch-helper";
 
 import { Widget } from "../base-widget";
 import { VERSION } from "../version";
@@ -157,7 +158,7 @@ export type InstantSearchConfig = {
   indexName: string;
 
   numberLocale?: string;
-  searchFunction?: () => void;
+  searchFunction?: (helper: AlgoliaSearchHelper) => void;
   createAlgoliaClient?: (
     algoliasearch: Function,
     appId: string,


### PR DESCRIPTION
According to the [documentation](https://community.algolia.com/angular-instantsearch/widgets/instantsearch.html#config-object-options), the `searchFunction` function takes the `helper` as a parameter.

see #232 