### PR TITLE
fix(community): fix DocSearch config

### DIFF
--- a/community-website/src/community-project-boilerplate-docgen/assets/js/main.js
+++ b/community-website/src/community-project-boilerplate-docgen/assets/js/main.js
@@ -6,8 +6,8 @@ import './sidebar-active-el';
 import { fixSidebar, followSidebarNavigation } from './fix-sidebar.js';
 
 const docSearch = {
-  appId: '6DKK9OCRLB',
-  apiKey: '1da2702c999d7bca6535c6f7f9c61e89',
+  appId: 'BH4D9OD16A',
+  apiKey: '20af0c88b675ef9215aaa9ab1ec36d99',
   indexName: 'angular-instantsearch',
   inputSelector: '#searchbox',
 };


### PR DESCRIPTION
The former DocSearch configuration was a specific index not owned by the DocSearch team. The configuration was not relevant (e.g. if you type `searchClient` or `backend`, no results are showing up).

This new configuration has been set up by @s-pace (huge thanks!) and should be more accurate.