### PR TITLE
fix(peerDependencies): allow peer dependencies >=5.0.0 <8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,9 +150,9 @@
     "zone.js": "0.8.26"
   },
   "peerDependencies": {
-    "@angular/common": ">=^5.0.0 <7.0.0",
-    "@angular/core": ">=^5.0.0 <7.0.0",
-    "@angular/platform-browser": ">=^5.0.0 <7.0.0",
-    "@angular/platform-browser-dynamic": ">=^5.0.0 <7.0.0"
+    "@angular/common": ">=5.0.0 <8.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
+    "@angular/platform-browser": ">=5.0.0 <8.0.0",
+    "@angular/platform-browser-dynamic": ">=5.0.0 <8.0.0"
   }
 }


### PR DESCRIPTION
- removed malformed >=^5.0.0 syntax
- added support for v7


After the version is release, I'll need to update the examples.