### PR TITLE
fix(build): include dev-novel build as part of the global build command

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,3 +16,6 @@ mv dist/bundles/reset-min.css dist/bundles/instantsearch.min.css
 
 mv dist/bundles/algolia.css dist/bundles/instantsearch-theme-algolia.css
 mv dist/bundles/algolia-min.css dist/bundles/instantsearch-theme-algolia.min.css
+
+# build dev-novel
+MODE=build webpack --config webpack.demo.js


### PR DESCRIPTION
The purpose of this change is to better detect build failures on dev-novel
Right now, dev-novel is only build in the netlify env, which empirically tends to swallow errors.

for example in this build: https://app.netlify.com/sites/angular-instantsearch/deploys/5bd9987f02ed833a3299b33c
```
1:02:57 PM: One CLI for webpack must be installed. These are recommended choices, delivered as separate packages:
1:02:57 PM:  - webpack-cli (https://github.com/webpack/webpack-cli)
1:02:57 PM:    The original webpack full-featured CLI.
1:02:57 PM: We will use "yarn" to install the CLI via "yarn add -D".
1:02:57 PM: Do you want to install 'webpack-cli' (yes/no): Done in 316.25s.
```
you can see that the unaswered prompt did not result in an error.
Ideally this should timeout and eventually fail.

If this change works as expect, the build will fail until #336 is merged