### PR TITLE
chore(docs): simplify build script

### DIFF
--- a/examples/angular-router/package.json
+++ b/examples/angular-router/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "start": "ng serve",
-    "build": "ng build --prod"
+    "build": "ng build --prod --base-href '.'"
   },
   "private": true,
   "dependencies": {

--- a/examples/e-commerce/package.json
+++ b/examples/e-commerce/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "start": "ng serve",
-    "build": "ng build --prod"
+    "build": "ng build --prod --base-href '.'"
   },
   "private": true,
   "dependencies": {

--- a/examples/media/package.json
+++ b/examples/media/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "start": "ng serve",
-    "build": "ng build --prod"
+    "build": "ng build --prod --base-href '.'"
   },
   "private": true,
   "dependencies": {

--- a/examples/server-side-rendering/package.json
+++ b/examples/server-side-rendering/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --preserve-symlinks",
-    "build": "ng build",
+    "build": "ng build --prod --base-href '.'",
     "build:client-and-server-bundles": "ng build --prod && ng build --prod --app 1 --output-hashing=false",
     "build:prerender": "npm run build:client-and-server-bundles && npm run webpack:server && npm run generate:prerender",
     "build:ssr": "npm run build:client-and-server-bundles && npm run webpack:server",

--- a/scripts/build-example.sh
+++ b/scripts/build-example.sh
@@ -19,5 +19,5 @@ yarn build
   mkdir -p ./node_modules/instantsearch.js
   cp -R ../../node_modules/instantsearch.js/* ./node_modules/instantsearch.js
 
-  ./node_modules/.bin/ng build --prod --base-href "."
+  yarn build
 )


### PR DESCRIPTION
Purpose: make the build-example script more generic
This is preparing the arrival of a new example "storybook", which will replace the dev-novel.
It doesn't build exactly like other angular apps, which is why I'm making the build script more generic