### PR TITLE
WIP feat(Breadcrumbs): templates

### DIFF
--- a/src/breadcrumb/__tests__/__snapshots__/breadcrumb.spec.ts.snap
+++ b/src/breadcrumb/__tests__/__snapshots__/breadcrumb.spec.ts.snap
@@ -10,6 +10,7 @@ exports[`Breadcrumb renders markup with two items 1`] = `
       <div
         class="ais-Breadcrumb"
       >
+        
         <ul
           class="ais-Breadcrumb-list"
         >
@@ -60,6 +61,7 @@ exports[`Breadcrumb renders markup without state 1`] = `
       <div
         class="ais-Breadcrumb"
       >
+        
         <ul
           class="ais-Breadcrumb-list"
         >

--- a/src/breadcrumb/breadcrumb.ts
+++ b/src/breadcrumb/breadcrumb.ts
@@ -1,4 +1,11 @@
-import { Component, Input, Inject, forwardRef, ContentChild, TemplateRef } from '@angular/core';
+import {
+  Component,
+  Input,
+  Inject,
+  forwardRef,
+  ContentChild,
+  TemplateRef,
+} from '@angular/core';
 import { connectBreadcrumb } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
@@ -18,10 +25,7 @@ export type BreadcrumbItem = {
 @Component({
   selector: 'ais-breadcrumb',
   template: `
-    <div
-      [class]="cx()"
-      *ngIf="!isHidden"
-    >
+    <div [class]="cx()" *ngIf="!isHidden">
       <ng-container *ngTemplateOutlet="template; context: state"></ng-container>
       <ul [class]="cx('list')">
         <li
@@ -42,12 +46,10 @@ export type BreadcrumbItem = {
             *ngIf="!item.isLast"
             (click)="handleClick($event, item)"
           >
-            {{item.name}}
+            {{ item.name }}
           </a>
 
-          <span *ngIf="item.isLast">
-            {{item.name}}
-          </span>
+          <span *ngIf="item.isLast"> {{ item.name }} </span>
         </li>
       </ul>
     </div>

--- a/src/breadcrumb/breadcrumb.ts
+++ b/src/breadcrumb/breadcrumb.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Inject, forwardRef } from '@angular/core';
+import { Component, Input, Inject, forwardRef, ContentChild, TemplateRef } from '@angular/core';
 import { connectBreadcrumb } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
@@ -22,6 +22,7 @@ export type BreadcrumbItem = {
       [class]="cx()"
       *ngIf="!isHidden"
     >
+      <ng-container *ngTemplateOutlet="template; context: state"></ng-container>
       <ul [class]="cx('list')">
         <li
           *ngFor="let item of items"
@@ -53,6 +54,7 @@ export type BreadcrumbItem = {
   `,
 })
 export class NgAisBreadcrumb extends BaseWidget {
+  @ContentChild(TemplateRef) public template?: TemplateRef<any>;
   // connector options
   @Input() public attributes: string[];
   @Input() public rootPath?: string;


### PR DESCRIPTION
adds support for ng-template

Usage:

```html
<ais-breadcrumb>
  <ng-template let-items="items">
    <ul>
      <li *ngFor="let item of items">{{ item.name }}</li>
    </ul>
  </ng-template>
</ais-breadcrumb>
```