### PR TITLE
fix(RefinementList): introduce showMore prop to hide showmore button

### DIFF
--- a/examples/storybook/src/stories/RefinementList.stories.ts
+++ b/examples/storybook/src/stories/RefinementList.stories.ts
@@ -25,6 +25,7 @@ storiesOf('RefinementList', module)
           <ais-refinement-list
             attribute="brand"
             operator="or"
+            [showMore]="true"
             [limit]="3"
             [showMoreLimit]="10"
           >

--- a/src/refinement-list/__tests__/refinement-list.spec.ts
+++ b/src/refinement-list/__tests__/refinement-list.spec.ts
@@ -112,6 +112,99 @@ describe('RefinementList', () => {
       fixture.detectChanges();
       return fixture;
     };
+    it('should not show [show more] button when showMore === false', () => {
+      const fixture = createFixture(
+        {},
+        {
+          limit: 5,
+        }
+      );
+
+      const showMoreBtn = fixture.debugElement.nativeElement.querySelector(
+        'button'
+      );
+      expect(showMoreBtn).toBe(null);
+    });
+
+    it('should show [show more] button when showMore === true', () => {
+      const fixture = createFixture(
+        {
+          toggleShowMore: jest.fn(),
+        },
+        {
+          showMore: true,
+          limit: 5,
+          showMoreLabel: 'Please more',
+          showLessLabel: 'Please less',
+        }
+      );
+
+      const showMoreBtn = fixture.debugElement.nativeElement.querySelector(
+        'button'
+      );
+      expect(showMoreBtn.innerHTML.trim()).toEqual('Please more');
+    });
+
+    it('should show [show more] button as disabled when canToggleShowMore === false', () => {
+      const fixture = createFixture(
+        {
+          toggleShowMore: jest.fn(),
+          canToggleShowMore: false,
+        },
+        {
+          showMore: true,
+          limit: 5,
+          showMoreLabel: 'Please more',
+          showLessLabel: 'Please less',
+        }
+      );
+
+      const showMoreBtn = fixture.debugElement.nativeElement.querySelector(
+        'button'
+      );
+      expect(showMoreBtn.disabled).toEqual(true);
+    });
+
+    it('should show [show more] button as enabled when canToggleShowMore === true', () => {
+      const fixture = createFixture(
+        {
+          toggleShowMore: jest.fn(),
+          canToggleShowMore: true,
+        },
+        {
+          showMore: true,
+          limit: 5,
+          showMoreLabel: 'Please more',
+          showLessLabel: 'Please less',
+        }
+      );
+
+      const showMoreBtn = fixture.debugElement.nativeElement.querySelector(
+        'button'
+      );
+      expect(showMoreBtn.disabled).toEqual(false);
+    });
+
+    it('should show [show less] button when isShowingMore === true', () => {
+      const fixture = createFixture(
+        {
+          toggleShowMore: jest.fn(),
+          isShowingMore: true,
+        },
+        {
+          showMore: true,
+          limit: 5,
+          showMoreLabel: 'Please more',
+          showLessLabel: 'Please less',
+        }
+      );
+
+      const showMoreBtn = fixture.debugElement.nativeElement.querySelector(
+        'button'
+      );
+      expect(showMoreBtn.innerHTML.trim()).toEqual('Please less');
+    });
+
     it('should have ais-RefinementList-showMore CSS class', () => {
       const fixture = createFixture(
         {
@@ -119,6 +212,7 @@ describe('RefinementList', () => {
           canToggleShowMore: true,
         },
         {
+          showMore: true,
           limit: 5,
           showMoreLimit: 10,
         }
@@ -140,6 +234,7 @@ describe('RefinementList', () => {
           canToggleShowMore: true,
         },
         {
+          showMore: true,
           limit: 5,
           showMoreLimit: 10,
         }

--- a/src/refinement-list/refinement-list.ts
+++ b/src/refinement-list/refinement-list.ts
@@ -57,8 +57,9 @@ export type RefinementListState = {
 
       <button
         [class]="cx('showMore')"
-        *ngIf="showMoreLimit && state.canToggleShowMore"
+        *ngIf="showMore"
         (click)="state.toggleShowMore()"
+        [disabled]="!state.canToggleShowMore"
       >
         {{state.isShowingMore ? showLessLabel : showMoreLabel}}
       </button>
@@ -78,6 +79,7 @@ export class NgAisRefinementList extends BaseWidget {
   @Input() public operator: 'or' | 'and' = 'or';
   @Input() public limit: number | string = 10;
   @Input() public showMoreLimit: number | string;
+  @Input() public showMore: boolean = false;
   @Input() public sortBy: string[] | ((item: object) => number);
 
   public state: RefinementListState = {


### PR DESCRIPTION
⚠️  breaking change

Priorly the user could control the display of the show more button with
by acting on the showMoreLimit prop. This internally changed the
canToggleShowMore state which eventually controlled the visibility of the button.

In other flavours it is controlled by an external prop showMore : Boolean.

This PR intends to make the behaviour consistent with other flavours

fixes #391 

