### PR TITLE
fix(SearchBox): searchAsYouType doesn't work

### DIFF
--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -98,7 +98,7 @@ describe('SearchBox', () => {
         expect(refine).toHaveBeenCalledWith('the query');
       });
 
-      it('should call refine when Form has been submit', () => {
+      it('should call refine when the form is submitted', () => {
         const form = fixture.debugElement.query(By.css('form'));
         form.nativeElement.dispatchEvent(new Event('submit'));
 

--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -84,7 +84,7 @@ describe('SearchBox', () => {
         searchBox.dispatchEvent(new Event('input'));
       });
 
-      it('should not call refine as you user is typing', () => {
+      it('should not call refine on each keystroke', () => {
         expect(refine).toHaveBeenCalledTimes(0);
       });
 

--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -47,7 +47,7 @@ describe('SearchBox', () => {
 
   describe('[searchAsYouType]', () => {
     describe('default behaviour', () => {
-      it('should call refine as your type by default', () => {
+      it('should call refine as you type by default', () => {
         const fixture = createRenderer({
           defaultState,
           template: '<ais-search-box></ais-search-box>',

--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -1,5 +1,6 @@
 import { createRenderer } from '../../../helpers/test-renderer';
 import { NgAisSearchBox } from '../search-box';
+import { By } from '@angular/platform-browser';
 
 const defaultState = {
   query: 'foo',
@@ -41,6 +42,69 @@ describe('SearchBox', () => {
       })();
       const widget = fixture.componentInstance.testedWidget;
       expect(document.activeElement).not.toBe(widget.searchBox.nativeElement);
+    });
+  });
+
+  describe('[searchAsYouType]', () => {
+    describe('default behaviour', () => {
+      it('should call refine as your type by default', () => {
+        const fixture = createRenderer({
+          defaultState,
+          template: '<ais-search-box></ais-search-box>',
+          TestedWidget: NgAisSearchBox,
+        })();
+        const widget = fixture.componentInstance.testedWidget;
+        const refine = jest.spyOn(widget.state, 'refine');
+
+        const searchBox = widget.searchBox.nativeElement;
+        searchBox.value = 'the query';
+        searchBox.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        expect(refine).toHaveBeenCalledTimes(1);
+        expect(refine).toHaveBeenCalledWith('the query');
+      });
+    });
+
+    describe('[searchAsYouType]="false"', () => {
+      let fixture;
+      let refine;
+
+      beforeEach(() => {
+        fixture = createRenderer({
+          defaultState,
+          template:
+            '<ais-search-box [searchAsYouType]="false"></ais-search-box>',
+          TestedWidget: NgAisSearchBox,
+        })();
+        const widget = fixture.componentInstance.testedWidget;
+        refine = jest.spyOn(widget.state, 'refine');
+
+        const searchBox = widget.searchBox.nativeElement;
+        searchBox.value = 'the query';
+        searchBox.dispatchEvent(new Event('input'));
+      });
+
+      it('should not call refine as you user is typing', () => {
+        expect(refine).toHaveBeenCalledTimes(0);
+      });
+
+      it('should call refine when submit button has been clicked', () => {
+        const submitButton = fixture.debugElement.query(
+          By.css('button[type="submit"]')
+        );
+        submitButton.nativeElement.dispatchEvent(new Event('click'));
+
+        expect(refine).toHaveBeenCalledTimes(1);
+        expect(refine).toHaveBeenCalledWith('the query');
+      });
+
+      it('should call refine when Form has been submit', () => {
+        const form = fixture.debugElement.query(By.css('form'));
+        form.nativeElement.dispatchEvent(new Event('submit'));
+
+        expect(refine).toHaveBeenCalledTimes(1);
+        expect(refine).toHaveBeenCalledWith('the query');
+      });
     });
   });
 });

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -117,7 +117,7 @@ export class NgAisSearchBox extends BaseWidget implements AfterViewInit {
     }
   }
 
-  public handleSubmit(event: MouseEvent) {
+  public handleSubmit(event: Event) {
     // send submit event to parent component
     this.submit.emit(event);
 

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -43,7 +43,6 @@ import { noop } from '../utils';
           [class]="cx('submit')"
           type="submit"
           title="{{submitTitle}}"
-          (click)="handleSubmit($event)"
         >
           <svg
             [ngClass]="cx('submitIcon')"
@@ -113,7 +112,6 @@ export class NgAisSearchBox extends BaseWidget implements AfterViewInit {
 
   public handleChange(query: string) {
     this.change.emit(query);
-
     if (this.searchAsYouType) {
       this.state.refine(query);
     }
@@ -126,7 +124,7 @@ export class NgAisSearchBox extends BaseWidget implements AfterViewInit {
     event.preventDefault();
 
     if (!this.searchAsYouType) {
-      this.state.refine(this.state.query);
+      this.state.refine(this.searchBox.nativeElement.value);
     }
   }
 


### PR DESCRIPTION
**Summary**
This PR is fixing the broken searchAsYouType property (fixes https://github.com/algolia/angular-instantsearch/issues/375)

**Before:**
When user typed a query into `<ais-search-box [searchAsYouType]="false"></ais-search-box>` and pressed enter, nothing happened

**Now:** 
When user types a query into `<ais-search-box [searchAsYouType]="false"></ais-search-box>` and presses enter, the refine method of the connector is called.



**Result**


![2019-02-08 11 57 11](https://user-images.githubusercontent.com/2982512/52474435-c9130100-2b98-11e9-84a1-e8b28c4dfd39.gif)
