### PR TITLE
feat(queryRules): add ais-query-rule-custom-data widget

### DIFF
--- a/examples/storybook/src/stories/Hits.stories.ts
+++ b/examples/storybook/src/stories/Hits.stories.ts
@@ -8,4 +8,19 @@ storiesOf('Hits', module)
     component: wrapWithHits({
       template: '<ais-hits></ais-hits>',
     }),
+  }))
+  .add('customized hits', () => ({
+    component: wrapWithHits({
+      template: `
+      <ais-hits>
+        <ng-template let-hits="hits">
+          <div *ngFor="let hit of hits">
+            Hit {{hit.objectID}}:
+            <ais-highlight attribute="name" [hit]="hit">
+            </ais-highlight>
+          </div>
+        </ng-template>
+      </ais-hits>
+      `,
+    }),
   }));

--- a/examples/storybook/src/stories/QueryRuleContext.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleContext.stories.ts
@@ -1,0 +1,162 @@
+import { storiesOf } from '@storybook/angular';
+import { wrapWithHits } from '../wrap-with-hits';
+import meta from '../meta';
+
+const moviesConfig = {
+  indexName: 'instant_search_movies',
+  filters: `<ais-refinement-list attribute="genre"></ais-refinement-list>`,
+  hits: `
+  <ng-template let-hits="hits">
+    <ol class="playground-hits">
+      <li
+        *ngFor="let hit of hits"
+        class="hit playground-hits-item"
+        id="hit-{{ hit.objectID }}"
+      >
+        <div
+          class="playground-hits-image"
+          [ngStyle]="{ 'background-image': 'url(' + hit.image + ')' }"
+        ></div>
+
+        <div class="playground-hits-desc">
+          <p>
+            <ais-highlight [hit]="hit" attribute="title"></ais-highlight>
+          </p>
+          <p>Genre: {{ hit.genre.join(", ") }}</p>
+        </div>
+      </li>
+    </ol>
+  </ng-template>
+  `,
+};
+
+storiesOf('QueryRuleContext', module)
+  .addDecorator(meta)
+  .add('default', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <ul>
+        <li>Select the "Drama" category and The Shawshank Redemption appears</li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>Type <q>music</q> and a banner will appear.</li>
+      </ul>
+
+      <ais-query-rule-context
+        [trackedFilters]="trackedFilters"
+      ></ais-query-rule-context>
+
+      <ais-query-rule-custom-data>
+        <ng-template let-items="items">
+          <div *ngFor="let item of items">
+            <h2>{{ item.title }}</h2>
+            <a [href]="item.link">
+              <img
+                [src]="item.banner"
+                [alt]="item.title"
+                [style.width]="'100%'"
+              />
+            </a>
+          </div>
+        </ng-template>
+      </ais-query-rule-custom-data>
+      `,
+      methods: {
+        trackedFilters: {
+          genre: () => ['Thriller', 'Drama'],
+        },
+      },
+    }),
+  }))
+  .add('with initial filter', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+    <ul>
+      <li>
+        Select the "Drama" category and The Shawshank Redemption appears
+      </li>
+      <li>Select the "Thriller" category and Pulp Fiction appears</li>
+      <li>Type <q>music</q> and a banner will appear.</li>
+    </ul>
+
+    <ais-configure
+      [searchParameters]="{
+        disjunctiveFacetsRefinements: {
+          genre: ['Drama']
+        }
+      }"
+    ></ais-configure>
+
+    <ais-query-rule-context
+      [trackedFilters]="trackedFilters"
+    ></ais-query-rule-context>
+
+    <ais-query-rule-custom-data>
+      <ng-template let-items="items">
+        <div *ngFor="let item of items">
+          <h2>{{ item.title }}</h2>
+          <a [href]="item.link">
+            <img
+              [src]="item.banner"
+              [alt]="item.title"
+              [style.width]="'100%'"
+            />
+          </a>
+        </div>
+      </ng-template>
+    </ais-query-rule-custom-data>
+    `,
+      methods: {
+        trackedFilters: {
+          genre: () => ['Thriller', 'Drama'],
+        },
+      },
+    }),
+  }))
+  .add('with initial rule context', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+    <ul>
+      <li>
+        Select the "Drama" category and The Shawshank Redemption appears
+      </li>
+      <li>Select the "Thriller" category and Pulp Fiction does not appear</li>
+      <li>Type <q>music</q> and a banner will appear.</li>
+    </ul>
+
+    <ais-query-rule-context
+      [trackedFilters]="trackedFilters"
+      [transformRuleContexts]="transformRuleContexts"
+    ></ais-query-rule-context>
+
+    <ais-query-rule-custom-data>
+      <ng-template let-items="items">
+        <div *ngFor="let item of items">
+          <h2>{{ item.title }}</h2>
+          <a [href]="item.link">
+            <img
+              [src]="item.banner"
+              [alt]="item.title"
+              [style.width]="'100%'"
+            />
+          </a>
+        </div>
+      </ng-template>
+    </ais-query-rule-custom-data>
+    `,
+      methods: {
+        trackedFilters: {
+          genre: values => values,
+        },
+        transformRuleContexts: ruleContexts => {
+          if (ruleContexts.length === 0) {
+            return ['ais-genre-Drama'];
+          }
+
+          return ruleContexts;
+        },
+      },
+    }),
+  }));

--- a/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
@@ -8,20 +8,21 @@ const moviesConfig = {
   hits: `
   <ng-template let-hits="hits">
     <ol class="playground-hits">
-
       <li
         *ngFor="let hit of hits"
         class="hit playground-hits-item"
-        id="hit-{{hit.objectID}}"
+        id="hit-{{ hit.objectID }}"
       >
-        <div class="playground-hits-image" [ngStyle]="{'background-image': 'url(' + hit.image + ')' }">
-        </div>
+        <div
+          class="playground-hits-image"
+          [ngStyle]="{ 'background-image': 'url(' + hit.image + ')' }"
+        ></div>
 
         <div class="playground-hits-desc">
           <p>
             <ais-highlight [hit]="hit" attribute="title"></ais-highlight>
           </p>
-          <p>Genre: {{hit.genre.join(', ')}}</p>
+          <p>Genre: {{ hit.genre.join(", ") }}</p>
         </div>
       </li>
     </ol>

--- a/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
@@ -124,7 +124,7 @@ storiesOf('QueryRuleCustomData', module)
       <ais-query-rule-custom-data [transformItems]="transformItems">
       </ais-query-rule-custom-data>`,
       methods: {
-        transformItems: (items) =>
+        transformItems: items =>
           items.filter(item => item.banner !== undefined),
       },
     }),

--- a/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
@@ -1,0 +1,131 @@
+import { storiesOf } from '@storybook/angular';
+import { wrapWithHits } from '../wrap-with-hits';
+import meta from '../meta';
+
+const moviesConfig = {
+  indexName: 'instant_search_movies',
+  filters: `<ais-refinement-list attribute="genre"></ais-refinement-list>`,
+  hits: `
+  <ng-template let-hits="hits">
+    <ol class="playground-hits">
+
+      <li
+        *ngFor="let hit of hits"
+        class="hit playground-hits-item"
+        id="hit-{{hit.objectID}}"
+      >
+        <div class="playground-hits-image" [ngStyle]="{'background-image': 'url(' + hit.image + ')' }">
+        </div>
+
+        <div class="playground-hits-desc">
+          <p>
+            <ais-highlight [hit]="hit" attribute="title"></ais-highlight>
+          </p>
+          <p>Genre: {{hit.genre.join(', ')}}</p>
+        </div>
+      </li>
+    </ol>
+  </ng-template>
+  `,
+};
+
+storiesOf('QueryRuleCustomData', module)
+  .addDecorator(meta)
+  .add('default', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: '<ais-query-rule-custom-data></ais-query-rule-custom-data>',
+    }),
+  }))
+  .add('custom items template', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <p>
+        Type <q>music</q> and a banner will appear.
+      </p>
+      <ais-query-rule-custom-data>
+        <ng-template let-items="items">
+          <div *ngFor="let item of items">
+            <h2>{{ item.title }}</h2>
+            <a [href]="item.link">
+              <img
+                [src]="item.banner"
+                [alt]="item.title"
+                [style.width]="'100%'"
+              />
+            </a>
+          </div>
+        </ng-template>
+      </ais-query-rule-custom-data>`,
+    }),
+  }))
+  .add('with default banner', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <p>
+        Kill Bill appears whenever no other results are promoted. Type
+        <q>music</q> to see another movie promoted.
+      </p>
+      <ais-query-rule-custom-data [transformItems]="transformItems">
+        <ng-template let-items="items">
+          <div *ngFor="let item of items">
+            <h2>{{ item.title }}</h2>
+            <a [href]="item.link">
+              <img
+                [src]="item.banner"
+                [alt]="item.title"
+                [style.width]="'100%'"
+              />
+            </a>
+          </div>
+        </ng-template>
+      </ais-query-rule-custom-data>`,
+      methods: {
+        transformItems: items => {
+          console.log('hi', items);
+          if (items.length > 0) {
+            return [items[0]];
+          }
+
+          return [
+            {
+              title: 'Kill Bill',
+              banner: 'http://static.bobatv.net/IMovie/mv_2352/poster_2352.jpg',
+              link: 'https://www.netflix.com/title/60031236',
+            },
+          ];
+        },
+      },
+    }),
+  }))
+  .add('picking first with transform', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <p>
+        Type <q>music</q> and a banner will appear.
+      </p>
+      <ais-query-rule-custom-data [transformItems]="transformItems">
+      </ais-query-rule-custom-data>`,
+      methods: {
+        transformItems: items => [items[0]],
+      },
+    }),
+  }))
+  .add('keeping only banners with transform', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <p>
+        Type <q>not a banner</q> and nothing will appear.
+      </p>
+      <ais-query-rule-custom-data [transformItems]="transformItems">
+      </ais-query-rule-custom-data>`,
+      methods: {
+        transformItems: (items) =>
+          items.filter(item => item.banner !== undefined),
+      },
+    }),
+  }));

--- a/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
@@ -2,6 +2,12 @@ import { storiesOf } from '@storybook/angular';
 import { wrapWithHits } from '../wrap-with-hits';
 import meta from '../meta';
 
+type CustomDataItem = {
+  title: string;
+  banner: string;
+  link: string;
+};
+
 const moviesConfig = {
   indexName: 'instant_search_movies',
   filters: `<ais-refinement-list attribute="genre"></ais-refinement-list>`,
@@ -35,7 +41,12 @@ storiesOf('QueryRuleCustomData', module)
   .add('default', () => ({
     component: wrapWithHits({
       ...moviesConfig,
-      template: '<ais-query-rule-custom-data></ais-query-rule-custom-data>',
+      template: `
+      <p>
+        Type <q>music</q> and a banner will appear.
+      </p>
+
+      <ais-query-rule-custom-data></ais-query-rule-custom-data>`,
     }),
   }))
   .add('custom items template', () => ({
@@ -45,6 +56,7 @@ storiesOf('QueryRuleCustomData', module)
       <p>
         Type <q>music</q> and a banner will appear.
       </p>
+
       <ais-query-rule-custom-data>
         <ng-template let-items="items">
           <div *ngFor="let item of items">
@@ -69,6 +81,7 @@ storiesOf('QueryRuleCustomData', module)
         Kill Bill appears whenever no other results are promoted. Type
         <q>music</q> to see another movie promoted.
       </p>
+
       <ais-query-rule-custom-data [transformItems]="transformItems">
         <ng-template let-items="items">
           <div *ngFor="let item of items">
@@ -84,7 +97,7 @@ storiesOf('QueryRuleCustomData', module)
         </ng-template>
       </ais-query-rule-custom-data>`,
       methods: {
-        transformItems: items => {
+        transformItems: (items: CustomDataItem[]) => {
           if (items.length > 0) {
             return [items[0]];
           }
@@ -97,35 +110,6 @@ storiesOf('QueryRuleCustomData', module)
             },
           ];
         },
-      },
-    }),
-  }))
-  .add('picking first with transform', () => ({
-    component: wrapWithHits({
-      ...moviesConfig,
-      template: `
-      <p>
-        Type <q>music</q> and a banner will appear.
-      </p>
-      <ais-query-rule-custom-data [transformItems]="transformItems">
-      </ais-query-rule-custom-data>`,
-      methods: {
-        transformItems: items => [items[0]],
-      },
-    }),
-  }))
-  .add('keeping only banners with transform', () => ({
-    component: wrapWithHits({
-      ...moviesConfig,
-      template: `
-      <p>
-        Type <q>not a banner</q> and nothing will appear.
-      </p>
-      <ais-query-rule-custom-data [transformItems]="transformItems">
-      </ais-query-rule-custom-data>`,
-      methods: {
-        transformItems: items =>
-          items.filter(item => item.banner !== undefined),
       },
     }),
   }));

--- a/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
@@ -112,4 +112,35 @@ storiesOf('QueryRuleCustomData', module)
         },
       },
     }),
+  }))
+  .add('picking first item with transformItems', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <p>
+        Type <q>music</q> and a banner will appear.
+      </p>
+
+      <ais-query-rule-custom-data [transformItems]="transformItems">
+      </ais-query-rule-custom-data>`,
+      methods: {
+        transformItems: (items: CustomDataItem[]) => [items[0]],
+      },
+    }),
+  }))
+  .add('keeping only banners with transformItems', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <p>
+        Type <q>not a banner</q> and nothing will appear.
+      </p>
+
+      <ais-query-rule-custom-data [transformItems]="transformItems">
+      </ais-query-rule-custom-data>`,
+      methods: {
+        transformItems: (items: CustomDataItem[]) =>
+          items.filter(item => item.banner !== undefined),
+      },
+    }),
   }));

--- a/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleCustomData.stories.ts
@@ -85,7 +85,6 @@ storiesOf('QueryRuleCustomData', module)
       </ais-query-rule-custom-data>`,
       methods: {
         transformItems: items => {
-          console.log('hi', items);
           if (items.length > 0) {
             return [items[0]];
           }

--- a/examples/storybook/src/wrap-with-hits.ts
+++ b/examples/storybook/src/wrap-with-hits.ts
@@ -14,7 +14,32 @@ type WrapWithHitsParams = {
   searchClient?: {};
   filters?: string;
   indexName?: string;
+  hits?: string;
 };
+
+const defaultHits = `
+<ng-template let-hits="hits">
+  <ol class="playground-hits">
+
+    <li
+      *ngFor="let hit of hits"
+      class="hit playground-hits-item"
+      id="hit-{{hit.objectID}}"
+    >
+      <div class="playground-hits-image" [ngStyle]="{'background-image': 'url(' + hit.image + ')' }">
+      </div>
+
+      <div class="playground-hits-desc">
+        <p>
+          <ais-highlight [hit]="hit" attribute="name"></ais-highlight>
+        </p>
+        <p>Rating: {{hit.rating}} ✭</p>
+        <p>Price: \${{hit.price}}</p>
+      </div>
+    </li>
+  </ol>
+</ng-template>
+`;
 
 export function wrapWithHits({
   template,
@@ -25,6 +50,7 @@ export function wrapWithHits({
   searchClient,
   indexName = 'instant_search',
   filters = `<ais-refinement-list attribute="brand"></ais-refinement-list>`,
+  hits = defaultHits,
 }: WrapWithHitsParams) {
   @Component({
     selector: 'ais-app',
@@ -41,27 +67,7 @@ export function wrapWithHits({
             <ais-search-box placeholder="Search into furniture"></ais-search-box>
             <ais-stats></ais-stats>
             <ais-hits>
-              <ng-template let-hits="hits">
-                <ol class="playground-hits">
-
-                  <li
-                    *ngFor="let hit of hits"
-                    class="hit playground-hits-item"
-                    id="hit-{{hit.objectID}}"
-                  >
-                    <div class="playground-hits-image" [ngStyle]="{'background-image': 'url(' + hit.image + ')' }">
-                    </div>
-
-                    <div class="playground-hits-desc">
-                      <p>
-                        <ais-highlight [hit]="hit" attribute="name"></ais-highlight>
-                      </p>
-                      <p>Rating: {{hit.rating}} ✭</p>
-                      <p>Price: \${{hit.price}}</p>
-                    </div>
-                  </li>
-                </ol>
-              </ng-template>
+              ${hits}
             </ais-hits>
             <ais-pagination [totalPages]="20"></ais-pagination>
           </div>

--- a/examples/storybook/src/wrap-with-hits.ts
+++ b/examples/storybook/src/wrap-with-hits.ts
@@ -20,7 +20,6 @@ type WrapWithHitsParams = {
 const defaultHits = `
 <ng-template let-hits="hits">
   <ol class="playground-hits">
-
     <li
       *ngFor="let hit of hits"
       class="hit playground-hits-item"

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "eslint-config-prettier": "3.6.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-prettier": "3.0.1",
-    "instantsearch.js": "3.1.0",
+    "instantsearch.js": "3.3.0",
     "jest": "23.6.0",
     "jest-preset-angular": "6.0.2",
     "ng-packagr": "4.7.0",
@@ -146,6 +146,6 @@
     "@angular/core": ">=5.0.0 <8.0.0",
     "@angular/platform-browser": ">=5.0.0 <8.0.0",
     "@angular/platform-browser-dynamic": ">=5.0.0 <8.0.0",
-    "instantsearch.js": "^3.1.0"
+    "instantsearch.js": "^3.3.0"
   }
 }

--- a/src/configure/__tests__/configure.spec.ts
+++ b/src/configure/__tests__/configure.spec.ts
@@ -25,7 +25,7 @@ describe('Configure', () => {
     fixture.detectChanges();
     // does not work because `searchParameters` is undefined, but works in real life
     // fixture.componentInstance.testedWidget.searchParameters.hi = "where?";
-    const searchParams: {} = {};
+    const searchParams: any = {};
     fixture.componentInstance.testedWidget.searchParameters = searchParams;
     searchParams.hi = 'where?';
     fixture.detectChanges();

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,8 @@ import { NgAisPanelModule } from './panel/panel.module';
 export { NgAisPanelModule };
 import { NgAisConfigureModule } from './configure/configure.module';
 export { NgAisConfigureModule };
+import { NgAisQueryRuleCustomDataModule } from './query-rule-custom-data/query-rule-custom-data.module';
+export { NgAisQueryRuleCustomDataModule };
 
 // Custom SSR algoliasearchClient
 import {
@@ -86,6 +88,7 @@ const NGIS_MODULES = [
   NgAisRangeInputModule,
   NgAisPanelModule,
   NgAisConfigureModule,
+  NgAisQueryRuleCustomDataModule,
 ];
 
 @NgModule({

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ import { NgAisConfigureModule } from './configure/configure.module';
 export { NgAisConfigureModule };
 import { NgAisQueryRuleCustomDataModule } from './query-rule-custom-data/query-rule-custom-data.module';
 export { NgAisQueryRuleCustomDataModule };
+import { NgAisQueryRuleContextModule } from './query-rule-context/query-rule-context.module';
+export { NgAisQueryRuleContextModule };
 
 // Custom SSR algoliasearchClient
 import {
@@ -89,6 +91,7 @@ const NGIS_MODULES = [
   NgAisPanelModule,
   NgAisConfigureModule,
   NgAisQueryRuleCustomDataModule,
+  NgAisQueryRuleContextModule,
 ];
 
 @NgModule({

--- a/src/query-rule-context/__tests__/__snapshots__/query-rule-context.spec.ts.snap
+++ b/src/query-rule-context/__tests__/__snapshots__/query-rule-context.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QueryRuleContext renders nothing with state 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleContext]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-context />
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`QueryRuleContext renders nothing without state 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleContext]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-context />
+  </ais-instantsearch>
+</ng-component>
+`;

--- a/src/query-rule-context/__tests__/query-rule-context.spec.ts
+++ b/src/query-rule-context/__tests__/query-rule-context.spec.ts
@@ -1,0 +1,70 @@
+import { createRenderer } from '../../../helpers/test-renderer';
+import { NgAisQueryRuleContext } from '../query-rule-context';
+
+describe('QueryRuleContext', () => {
+  let render;
+  let createWidget;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    createWidget = jest.spyOn(NgAisQueryRuleContext.prototype, 'createWidget');
+
+    render = (template: string, state?: object) =>
+      createRenderer({
+        defaultState: state,
+        template,
+        TestedWidget: NgAisQueryRuleContext,
+      })({});
+  });
+
+  it('renders nothing without state', () => {
+    const template = '<ais-query-rule-context></ais-query-rule-context>';
+    const state = undefined;
+
+    const fixture = render(template, state);
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('renders nothing with state', () => {
+    const template = '<ais-query-rule-context></ais-query-rule-context>';
+    const state = {
+      items: ['Luke', 'I am', 'your father'],
+    };
+
+    const fixture = render(template, state);
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('passes trackedFilters', () => {
+    const trackedFilters = 'trackedFilters';
+    const template = `<ais-query-rule-context
+      [trackedFilters]="'${trackedFilters}'"
+    >
+    </ais-query-rule-context>`;
+    const state = {};
+
+    render(template, state);
+
+    expect(createWidget.mock.calls[0][1].trackedFilters).toEqual(
+      trackedFilters
+    );
+  });
+
+  it('passes transformRuleContexts', () => {
+    const transformRuleContexts = 'transformRuleContexts';
+    const template = `<ais-query-rule-context
+      [transformRuleContexts]="'${transformRuleContexts}'"
+    >
+    </ais-query-rule-context>`;
+    const state = {};
+
+    render(template, state);
+
+    expect(createWidget.mock.calls[0][1].transformRuleContexts).toEqual(
+      transformRuleContexts
+    );
+  });
+});

--- a/src/query-rule-context/query-rule-context.module.ts
+++ b/src/query-rule-context/query-rule-context.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { NgAisQueryRuleContext } from './query-rule-context';
+
+@NgModule({
+  declarations: [NgAisQueryRuleContext],
+  entryComponents: [NgAisQueryRuleContext],
+  exports: [NgAisQueryRuleContext],
+  imports: [CommonModule],
+})
+export class NgAisQueryRuleContextModule {}

--- a/src/query-rule-context/query-rule-context.ts
+++ b/src/query-rule-context/query-rule-context.ts
@@ -1,0 +1,35 @@
+import { Component, Input, Inject, forwardRef } from '@angular/core';
+
+import { connectQueryRules } from 'instantsearch.js/es/connectors';
+import { BaseWidget } from '../base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
+
+type FacetValue = string | number | boolean;
+
+@Component({
+  selector: 'ais-query-rule-context',
+  template: '',
+})
+export class NgAisQueryRuleContext extends BaseWidget {
+  @Input()
+  public trackedFilters: {
+    [facetName: string]: (facetValues: FacetValue[]) => FacetValue[];
+  };
+  @Input() public transformRuleContexts?: (items: string[]) => string[];
+
+  constructor(
+    @Inject(forwardRef(() => NgAisInstantSearch))
+    public instantSearchParent: any
+  ) {
+    super('QueryRuleContext');
+  }
+
+  public ngOnInit() {
+    this.createWidget(connectQueryRules, {
+      trackedFilters: this.trackedFilters,
+      transformRuleContexts: this.transformRuleContexts,
+    });
+
+    super.ngOnInit();
+  }
+}

--- a/src/query-rule-custom-data/__tests__/__snapshots__/query-rule-custom-data.spec.ts.snap
+++ b/src/query-rule-custom-data/__tests__/__snapshots__/query-rule-custom-data.spec.ts.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QueryRuleCustomData should render with state 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleCustomData]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-custom-data>
+      <div
+        class="ais-QueryRuleCustomData"
+      >
+        
+        
+        <div>
+          
+          <div>
+            <pre>
+              {
+    "banner": "lol yes it is a banner"
+  }
+            </pre>
+          </div>
+        </div>
+      </div>
+    </ais-query-rule-custom-data>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`QueryRuleCustomData should render without state 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleCustomData]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-custom-data>
+      <div
+        class="ais-QueryRuleCustomData"
+      >
+        
+        
+        <div>
+          
+        </div>
+      </div>
+    </ais-query-rule-custom-data>
+  </ais-instantsearch>
+</ng-component>
+`;

--- a/src/query-rule-custom-data/__tests__/__snapshots__/query-rule-custom-data.spec.ts.snap
+++ b/src/query-rule-custom-data/__tests__/__snapshots__/query-rule-custom-data.spec.ts.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`QueryRuleCustomData should render with custom template 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleCustomData]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-custom-data>
+      <div
+        class="ais-QueryRuleCustomData"
+      >
+        
+        
+        <div>
+          <img
+            alt="Banner 1"
+            src="1.jpg"
+          />
+        </div>
+        <div>
+          <img
+            alt="Banner 1"
+            src="2.jpg"
+          />
+        </div>
+        
+        
+      </div>
+    </ais-query-rule-custom-data>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`QueryRuleCustomData should render with custom templates 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleCustomData]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-custom-data>
+      <div
+        class="ais-QueryRuleCustomData"
+      >
+        
+        
+        <div>
+          <img
+            alt="Banner 1"
+            src="1.jpg"
+          />
+        </div>
+        <div>
+          <img
+            alt="Banner 1"
+            src="2.jpg"
+          />
+        </div>
+        
+        
+      </div>
+    </ais-query-rule-custom-data>
+  </ais-instantsearch>
+</ng-component>
+`;
+
 exports[`QueryRuleCustomData should render with state 1`] = `
 <ng-component
   testedWidget={[Function NgAisQueryRuleCustomData]}
@@ -16,7 +78,14 @@ exports[`QueryRuleCustomData should render with state 1`] = `
           <div>
             <pre>
               {
-    "banner": "lol yes it is a banner"
+    "banner": "1.jpg"
+  }
+            </pre>
+          </div>
+          <div>
+            <pre>
+              {
+    "banner": "2.jpg"
   }
             </pre>
           </div>

--- a/src/query-rule-custom-data/__tests__/__snapshots__/query-rule-custom-data.spec.ts.snap
+++ b/src/query-rule-custom-data/__tests__/__snapshots__/query-rule-custom-data.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`QueryRuleCustomData should render with custom template 1`] = `
+exports[`QueryRuleCustomData should render with custom templates 1`] = `
 <ng-component
   testedWidget={[Function NgAisQueryRuleCustomData]}
 >
@@ -31,7 +31,7 @@ exports[`QueryRuleCustomData should render with custom template 1`] = `
 </ng-component>
 `;
 
-exports[`QueryRuleCustomData should render with custom templates 1`] = `
+exports[`QueryRuleCustomData should render with empty state 1`] = `
 <ng-component
   testedWidget={[Function NgAisQueryRuleCustomData]}
 >
@@ -43,19 +43,8 @@ exports[`QueryRuleCustomData should render with custom templates 1`] = `
         
         
         <div>
-          <img
-            alt="Banner 1"
-            src="1.jpg"
-          />
+          
         </div>
-        <div>
-          <img
-            alt="Banner 1"
-            src="2.jpg"
-          />
-        </div>
-        
-        
       </div>
     </ais-query-rule-custom-data>
   </ais-instantsearch>

--- a/src/query-rule-custom-data/__tests__/query-rule-custom-data.spec.ts
+++ b/src/query-rule-custom-data/__tests__/query-rule-custom-data.spec.ts
@@ -1,22 +1,77 @@
 import { createRenderer } from '../../../helpers/test-renderer';
 import { NgAisQueryRuleCustomData } from '../query-rule-custom-data';
 
-const render = createRenderer({
-  defaultState: {
-    items: [{ banner: 'lol yes it is a banner' }],
-  },
-  template: '<ais-query-rule-custom-data></ais-query-rule-custom-data>',
-  TestedWidget: NgAisQueryRuleCustomData,
-});
-
 describe('QueryRuleCustomData', () => {
+  let render;
+  let createWidget;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createWidget = jest.spyOn(
+      NgAisQueryRuleCustomData.prototype,
+      'createWidget'
+    );
+
+    render = (template: string, state: object = {}) =>
+      createRenderer({
+        defaultState: state,
+        template,
+        TestedWidget: NgAisQueryRuleCustomData,
+      })({});
+  });
+
   it('should render without state', () => {
-    const fixture = render();
+    const template = `<ais-query-rule-custom-data></ais-query-rule-custom-data>`;
+
+    const fixture = render(template);
+
     expect(fixture).toMatchSnapshot();
   });
 
   it('should render with state', () => {
-    const fixture = render({});
+    const template = `<ais-query-rule-custom-data></ais-query-rule-custom-data>`;
+    const state = { items: [{ banner: '1.jpg' }, { banner: '2.jpg' }] };
+
+    const fixture = render(template, state);
+
     expect(fixture).toMatchSnapshot();
+  });
+
+  it('should render with custom templates', () => {
+    const template = `
+<ais-query-rule-custom-data>
+  <ng-template let-items="items">
+    <div *ngFor="let item of items">
+      <img src="{{item.banner}}" alt="{{item.title}}">
+    </div>
+  </ng-template>
+</ais-query-rule-custom-data>
+    `;
+    const state = {
+      items: [
+        { title: 'Banner 1', banner: '1.jpg' },
+        { title: 'Banner 1', banner: '2.jpg' },
+      ],
+    };
+
+    const fixture = render(template, state);
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('passes transformItems', () => {
+    const transformItems = 'transformItems';
+
+    const fixture = render(
+      `<ais-query-rule-custom-data
+          [transformItems]="'${transformItems}'"
+        >
+        </ais-query-rule-custom-data>`,
+      { items: [{ banner: '1.jpg' }, { banner: '2.jpg' }] }
+    );
+
+    expect(createWidget.mock.calls[0][1].transformItems).toEqual(
+      transformItems
+    );
   });
 });

--- a/src/query-rule-custom-data/__tests__/query-rule-custom-data.spec.ts
+++ b/src/query-rule-custom-data/__tests__/query-rule-custom-data.spec.ts
@@ -1,0 +1,22 @@
+import { createRenderer } from '../../../helpers/test-renderer';
+import { NgAisQueryRuleCustomData } from '../query-rule-custom-data';
+
+const render = createRenderer({
+  defaultState: {
+    items: [{ banner: 'lol yes it is a banner' }],
+  },
+  template: '<ais-query-rule-custom-data></ais-query-rule-custom-data>',
+  TestedWidget: NgAisQueryRuleCustomData,
+});
+
+describe('QueryRuleCustomData', () => {
+  it('should render without state', () => {
+    const fixture = render();
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should render with state', () => {
+    const fixture = render({});
+    expect(fixture).toMatchSnapshot();
+  });
+});

--- a/src/query-rule-custom-data/__tests__/query-rule-custom-data.spec.ts
+++ b/src/query-rule-custom-data/__tests__/query-rule-custom-data.spec.ts
@@ -12,7 +12,7 @@ describe('QueryRuleCustomData', () => {
       'createWidget'
     );
 
-    render = (template: string, state: object = {}) =>
+    render = (template: string, state?: object) =>
       createRenderer({
         defaultState: state,
         template,
@@ -22,8 +22,18 @@ describe('QueryRuleCustomData', () => {
 
   it('should render without state', () => {
     const template = `<ais-query-rule-custom-data></ais-query-rule-custom-data>`;
+    const state = undefined;
 
-    const fixture = render(template);
+    const fixture = render(template, state);
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should render with empty state', () => {
+    const template = `<ais-query-rule-custom-data></ais-query-rule-custom-data>`;
+    const state = {};
+
+    const fixture = render(template, state);
 
     expect(fixture).toMatchSnapshot();
   });

--- a/src/query-rule-custom-data/query-rule-custom-data.module.ts
+++ b/src/query-rule-custom-data/query-rule-custom-data.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { NgAisQueryRuleCustomData } from './query-rule-custom-data';
+
+@NgModule({
+  declarations: [NgAisQueryRuleCustomData],
+  entryComponents: [NgAisQueryRuleCustomData],
+  exports: [NgAisQueryRuleCustomData],
+  imports: [CommonModule],
+})
+export class NgAisQueryRuleCustomDataModule {}

--- a/src/query-rule-custom-data/query-rule-custom-data.ts
+++ b/src/query-rule-custom-data/query-rule-custom-data.ts
@@ -30,14 +30,16 @@ import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 export class NgAisQueryRuleCustomData extends BaseWidget {
   @ContentChild(TemplateRef) public template: any;
 
-  @Input() public transformItems?: <U extends {}>(items: {}[]) => U[];
+  @Input() public transformItems?: (items: any[]) => any[];
 
   public state = {
     items: [],
   };
 
   get templateContext() {
-    return { items: this.state.items };
+    return {
+      items: this.state.items,
+    };
   }
 
   constructor(

--- a/src/query-rule-custom-data/query-rule-custom-data.ts
+++ b/src/query-rule-custom-data/query-rule-custom-data.ts
@@ -1,0 +1,56 @@
+import {
+  Component,
+  ContentChild,
+  TemplateRef,
+  Inject,
+  forwardRef,
+  Input,
+} from '@angular/core';
+
+import { connectQueryRules } from 'instantsearch.js/es/connectors';
+
+import { BaseWidget } from '../base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
+
+@Component({
+  selector: 'ais-query-rule-custom-data',
+  template: `
+    <div [class]="cx()">
+      <ng-container *ngTemplateOutlet="template; context: templateContext">
+      </ng-container>
+
+      <div *ngIf="!template">
+        <div *ngFor="let item of state.items">
+          <pre>{{ item | json }}</pre>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class NgAisQueryRuleCustomData extends BaseWidget {
+  @ContentChild(TemplateRef) public template: any;
+
+  @Input() public transformItems?: <U extends {}>(items: {}[]) => U[];
+
+  public state = {
+    items: [],
+  };
+
+  get templateContext() {
+    return { items: this.state.items };
+  }
+
+  constructor(
+    @Inject(forwardRef(() => NgAisInstantSearch))
+    public instantSearchParent: any
+  ) {
+    super('QueryRuleCustomData');
+  }
+
+  public ngOnInit() {
+    this.createWidget(connectQueryRules, {
+      transformItems: this.transformItems,
+    });
+    super.ngOnInit();
+  }
+}

--- a/src/query-rule-custom-data/query-rule-custom-data.ts
+++ b/src/query-rule-custom-data/query-rule-custom-data.ts
@@ -53,6 +53,7 @@ export class NgAisQueryRuleCustomData extends BaseWidget {
     this.createWidget(connectQueryRules, {
       transformItems: this.transformItems,
     });
+
     super.ngOnInit();
   }
 }

--- a/src/refinement-list/__tests__/refinement-list.spec.ts
+++ b/src/refinement-list/__tests__/refinement-list.spec.ts
@@ -55,7 +55,7 @@ describe('RefinementList', () => {
       expect(createWidget.mock.calls[0][0]).toEqual(connectRefinementList);
     });
     it('should be called with attributeName undefined by default', () => {
-      render(`<ais-refinement-list></ais-refinement-list>\``);
+      render(`<ais-refinement-list></ais-refinement-list>`);
       expect(createWidget.mock.calls[0][1].attribute).toBeUndefined();
     });
     it('should be called with attributeName passed down by attribute prop', () => {

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,8 @@
   "rules": {
     "prettier": true,
     "no-submodule-imports": false,
-    "import-name": false
+    "import-name": false,
+    "object-shorthand-properties-first": false
   },
   "cliOptions": {
     "exclude": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,17 +3347,17 @@ instantsearch.css@^7.0.0:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.1.1.tgz#64fa9f07ff39ab088b00cd3f0fa3ea697d2215f7"
   integrity sha512-8+2FLbZk9uK+VRFJ4tXByMNX9KTsPOrY/nkw4oe+8HH+jcHoVMQkUdxbFu7mSUHUdZjh5kK9Xk8IQau1Sy+VKw==
 
-instantsearch.js@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-3.1.0.tgz#e6335a110b4ca6741c84d1f20b4acd183239540f"
-  integrity sha512-HS5UB90aLEloar0mX/ZfkJ2/cwEOZDSE+N4jliB3pjSFHduLtiRvYKlvifYu8MdmPU9QAmDnlVlixFo2ZW7ETw==
+instantsearch.js@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-3.3.0.tgz#76eb6c796b65c5705561f80f2991b0716cf09e08"
+  integrity sha512-rVKzQbJz1HpEfr2o6BZ2IPtm+a8/76uVdG4zqNdGkuqfWc+DtNXYpLC12r7eyKQJQVf1o/zRUu9wQwF7TJgGrA==
   dependencies:
     algoliasearch-helper "^2.26.0"
     classnames "^2.2.5"
     events "^1.1.0"
     hogan.js "^3.0.2"
     lodash "^4.17.5"
-    preact "^8.2.7"
+    preact "^8.3.0"
     preact-compat "^3.18.0"
     preact-rheostat "^2.1.1"
     prop-types "^15.5.10"
@@ -5472,7 +5472,7 @@ preact-transition-group@^1.1.1:
   resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
   integrity sha1-8KSTJ+pRXs406ivoZMSn0p5dbhA=
 
-preact@^8.2.5, preact@^8.2.7:
+preact@^8.2.5, preact@^8.3.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.4.2.tgz#1263b974a17d1ea80b66590e41ef786ced5d6a23"
   integrity sha512-TsINETWiisfB6RTk0wh3/mvxbGRvx+ljeBccZ4Z6MPFKgu/KFGyf2Bmw3Z/jlXhL5JlNKY6QAbA9PVyzIy9//A==


### PR DESCRIPTION
This adds the `ais-query-rule-custom-data` widget based on the InstantSearch.js `queryRules` connector.