### PR TITLE
 feat(queryRules): add ais-query-rule-context widget

### DIFF
--- a/examples/storybook/src/stories/QueryRuleContext.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleContext.stories.ts
@@ -114,7 +114,7 @@ storiesOf('QueryRuleContext', module)
       },
     }),
   }))
-  .add('with initial context rule', () => ({
+  .add('with initial rule context', () => ({
     component: wrapWithHits({
       ...moviesConfig,
       template: `

--- a/examples/storybook/src/stories/QueryRuleContext.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleContext.stories.ts
@@ -1,0 +1,165 @@
+import { storiesOf } from '@storybook/angular';
+import { wrapWithHits } from '../wrap-with-hits';
+import meta from '../meta';
+
+const moviesConfig = {
+  indexName: 'instant_search_movies',
+  filters: `<ais-refinement-list attribute="genre"></ais-refinement-list>`,
+  hits: `
+  <ng-template let-hits="hits">
+    <ol class="playground-hits">
+      <li
+        *ngFor="let hit of hits"
+        class="hit playground-hits-item"
+        id="hit-{{ hit.objectID }}"
+      >
+        <div
+          class="playground-hits-image"
+          [ngStyle]="{ 'background-image': 'url(' + hit.image + ')' }"
+        ></div>
+
+        <div class="playground-hits-desc">
+          <p>
+            <ais-highlight [hit]="hit" attribute="title"></ais-highlight>
+          </p>
+          <p>Genre: {{ hit.genre.join(", ") }}</p>
+        </div>
+      </li>
+    </ol>
+  </ng-template>
+  `,
+};
+
+storiesOf('QueryRuleContext', module)
+  .addDecorator(meta)
+  .add('default', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+      <ul>
+        <li>Select the "Drama" category and The Shawshank Redemption appears</li>
+        <li>Select the "Thriller" category and Pulp Fiction appears</li>
+        <li>Type <q>music</q> and a banner will appear.</li>
+      </ul>
+
+      <ais-query-rule-context
+        [trackedFilters]="trackedFilters"
+      ></ais-query-rule-context>
+
+      <ais-query-rule-custom-data>
+        <ng-template let-items="items">
+          <div *ngFor="let item of items">
+            <h2>{{ item.title }}</h2>
+            <a [href]="item.link">
+              <img
+                [src]="item.banner"
+                [alt]="item.title"
+                [style.width]="'100%'"
+              />
+            </a>
+          </div>
+        </ng-template>
+      </ais-query-rule-custom-data>
+      `,
+      methods: {
+        trackedFilters: {
+          genre: () => ['Thriller', 'Drama'],
+        },
+      },
+    }),
+  }))
+  .add('with initial filter applied', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+    <ul>
+      <li>
+        Select the "Drama" category and The Shawshank Redemption appears
+      </li>
+      <li>Select the "Thriller" category and Pulp Fiction appears</li>
+      <li>Type <q>music</q> and a banner will appear.</li>
+    </ul>
+
+    <ais-configure
+      [searchParameters]="{
+        disjunctiveFacetsRefinements: {
+          genre: ['Drama']
+        }
+      }"
+    ></ais-configure>
+
+    <ais-query-rule-context
+      [trackedFilters]="trackedFilters"
+    ></ais-query-rule-context>
+
+    <ais-query-rule-custom-data>
+      <ng-template let-items="items">
+        <div *ngFor="let item of items">
+          <h2>{{ item.title }}</h2>
+          <a [href]="item.link">
+            <img
+              [src]="item.banner"
+              [alt]="item.title"
+              [style.width]="'100%'"
+            />
+          </a>
+        </div>
+      </ng-template>
+    </ais-query-rule-custom-data>
+    `,
+      methods: {
+        trackedFilters: {
+          genre: () => ['Thriller', 'Drama'],
+        },
+      },
+    }),
+  }))
+  .add('with filter out "thriller" in generated rules', () => ({
+    component: wrapWithHits({
+      ...moviesConfig,
+      template: `
+    <ul>
+      <li>
+        Select the "Drama" category and The Shawshank Redemption appears
+      </li>
+      <li>Select the "Thriller" category and Pulp Fiction does not appear</li>
+      <li>Type <q>music</q> and a banner will appear.</li>
+    </ul>
+
+    <ais-configure
+      [searchParameters]="{
+        disjunctiveFacetsRefinements: {
+          genre: ['Drama']
+        }
+      }"
+    ></ais-configure>
+
+    <ais-query-rule-context
+      [trackedFilters]="trackedFilters"
+      [transformRuleContexts]="transformRuleContexts"
+    ></ais-query-rule-context>
+
+    <ais-query-rule-custom-data>
+      <ng-template let-items="items">
+        <div *ngFor="let item of items">
+          <h2>{{ item.title }}</h2>
+          <a [href]="item.link">
+            <img
+              [src]="item.banner"
+              [alt]="item.title"
+              [style.width]="'100%'"
+            />
+          </a>
+        </div>
+      </ng-template>
+    </ais-query-rule-custom-data>
+    `,
+      methods: {
+        trackedFilters: {
+          genre: values => values,
+        },
+        transformRuleContexts: rules =>
+          rules.filter(rule => rule.indexOf('Thriller') < 0),
+      },
+    }),
+  }));

--- a/examples/storybook/src/stories/QueryRuleContext.stories.ts
+++ b/examples/storybook/src/stories/QueryRuleContext.stories.ts
@@ -68,7 +68,7 @@ storiesOf('QueryRuleContext', module)
       },
     }),
   }))
-  .add('with initial filter applied', () => ({
+  .add('with initial filter', () => ({
     component: wrapWithHits({
       ...moviesConfig,
       template: `
@@ -114,7 +114,7 @@ storiesOf('QueryRuleContext', module)
       },
     }),
   }))
-  .add('with filter out "thriller" in generated rules', () => ({
+  .add('with initial context rule', () => ({
     component: wrapWithHits({
       ...moviesConfig,
       template: `
@@ -125,14 +125,6 @@ storiesOf('QueryRuleContext', module)
       <li>Select the "Thriller" category and Pulp Fiction does not appear</li>
       <li>Type <q>music</q> and a banner will appear.</li>
     </ul>
-
-    <ais-configure
-      [searchParameters]="{
-        disjunctiveFacetsRefinements: {
-          genre: ['Drama']
-        }
-      }"
-    ></ais-configure>
 
     <ais-query-rule-context
       [trackedFilters]="trackedFilters"
@@ -158,8 +150,13 @@ storiesOf('QueryRuleContext', module)
         trackedFilters: {
           genre: values => values,
         },
-        transformRuleContexts: rules =>
-          rules.filter(rule => rule.indexOf('Thriller') < 0),
+        transformRuleContexts: ruleContexts => {
+          if (ruleContexts.length === 0) {
+            return ['ais-genre-Drama'];
+          }
+
+          return ruleContexts;
+        },
       },
     }),
   }));

--- a/src/configure/__tests__/configure.spec.ts
+++ b/src/configure/__tests__/configure.spec.ts
@@ -25,7 +25,7 @@ describe('Configure', () => {
     fixture.detectChanges();
     // does not work because `searchParameters` is undefined, but works in real life
     // fixture.componentInstance.testedWidget.searchParameters.hi = "where?";
-    const searchParams: {} = {};
+    const searchParams: any = {};
     fixture.componentInstance.testedWidget.searchParameters = searchParams;
     searchParams.hi = 'where?';
     fixture.detectChanges();

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ import { NgAisConfigureModule } from './configure/configure.module';
 export { NgAisConfigureModule };
 import { NgAisQueryRuleCustomDataModule } from './query-rule-custom-data/query-rule-custom-data.module';
 export { NgAisQueryRuleCustomDataModule };
+import { NgAisQueryRuleContextModule } from './query-rule-context/query-rule-context.module';
+export { NgAisQueryRuleContextModule };
 
 // Custom SSR algoliasearchClient
 import {
@@ -89,6 +91,7 @@ const NGIS_MODULES = [
   NgAisPanelModule,
   NgAisConfigureModule,
   NgAisQueryRuleCustomDataModule,
+  NgAisQueryRuleContextModule,
 ];
 
 @NgModule({

--- a/src/query-rule-context/__tests__/__snapshots__/query-rule-context.spec.ts.snap
+++ b/src/query-rule-context/__tests__/__snapshots__/query-rule-context.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`QueryRuleContext renders nothing with state 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleContext]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-context />
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`QueryRuleContext renders nothing without state 1`] = `
+<ng-component
+  testedWidget={[Function NgAisQueryRuleContext]}
+>
+  <ais-instantsearch>
+    <ais-query-rule-context />
+  </ais-instantsearch>
+</ng-component>
+`;

--- a/src/query-rule-context/__tests__/query-rule-context.spec.ts
+++ b/src/query-rule-context/__tests__/query-rule-context.spec.ts
@@ -1,0 +1,57 @@
+import { createRenderer } from '../../../helpers/test-renderer';
+import { NgAisQueryRuleContext } from '../query-rule-context';
+
+const defaultState = {
+  items: ['hello'],
+};
+
+describe('QueryRuleContext', () => {
+  let render;
+  let createWidget;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createWidget = jest.spyOn(NgAisQueryRuleContext.prototype, 'createWidget');
+    render = (template, state = defaultState) =>
+      createRenderer({
+        defaultState: state,
+        template,
+        TestedWidget: NgAisQueryRuleContext,
+      })({});
+  });
+
+  it('renders nothing without state', () => {
+    const fixture = render('<ais-query-rule-context></ais-query-rule-context>');
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('renders nothing with state', () => {
+    const fixture = render(
+      '<ais-query-rule-context></ais-query-rule-context>',
+      {
+        items: ['Luke', 'I am', 'your father'],
+      }
+    );
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('passes trackedFilters and transformRuleContexts', () => {
+    const trackedFilters = 'myTrackedFilters';
+    const transformRuleContexts = 'myTransformRuleContexts';
+    render(
+      `<ais-query-rule-context
+        [trackedFilters]="'${trackedFilters}'"
+        [transformRuleContexts]="'${transformRuleContexts}'"
+      >
+      </ais-query-rule-context>`
+    );
+
+    expect(createWidget.mock.calls[0][1].trackedFilters).toEqual(
+      trackedFilters
+    );
+    expect(createWidget.mock.calls[0][1].transformRuleContexts).toEqual(
+      transformRuleContexts
+    );
+  });
+});

--- a/src/query-rule-context/__tests__/query-rule-context.spec.ts
+++ b/src/query-rule-context/__tests__/query-rule-context.spec.ts
@@ -1,17 +1,16 @@
 import { createRenderer } from '../../../helpers/test-renderer';
 import { NgAisQueryRuleContext } from '../query-rule-context';
 
-const defaultState = {
-  items: ['hello'],
-};
-
 describe('QueryRuleContext', () => {
   let render;
   let createWidget;
+
   beforeEach(() => {
     jest.clearAllMocks();
+
     createWidget = jest.spyOn(NgAisQueryRuleContext.prototype, 'createWidget');
-    render = (template, state = defaultState) =>
+
+    render = (template: string, state?: object) =>
       createRenderer({
         defaultState: state,
         template,
@@ -20,36 +19,50 @@ describe('QueryRuleContext', () => {
   });
 
   it('renders nothing without state', () => {
-    const fixture = render('<ais-query-rule-context></ais-query-rule-context>');
+    const template = '<ais-query-rule-context></ais-query-rule-context>';
+    const state = undefined;
+
+    const fixture = render(template, state);
 
     expect(fixture).toMatchSnapshot();
   });
 
   it('renders nothing with state', () => {
-    const fixture = render(
-      '<ais-query-rule-context></ais-query-rule-context>',
-      {
-        items: ['Luke', 'I am', 'your father'],
-      }
-    );
+    const template = '<ais-query-rule-context></ais-query-rule-context>';
+    const state = {
+      items: ['Luke', 'I am', 'your father'],
+    };
+
+    const fixture = render(template, state);
 
     expect(fixture).toMatchSnapshot();
   });
 
-  it('passes trackedFilters and transformRuleContexts', () => {
-    const trackedFilters = 'myTrackedFilters';
-    const transformRuleContexts = 'myTransformRuleContexts';
-    render(
-      `<ais-query-rule-context
-        [trackedFilters]="'${trackedFilters}'"
-        [transformRuleContexts]="'${transformRuleContexts}'"
-      >
-      </ais-query-rule-context>`
-    );
+  it('passes trackedFilters', () => {
+    const trackedFilters = 'trackedFilters';
+    const template = `<ais-query-rule-context
+      [trackedFilters]="'${trackedFilters}'"
+    >
+    </ais-query-rule-context>`;
+    const state = {};
+
+    render(template, state);
 
     expect(createWidget.mock.calls[0][1].trackedFilters).toEqual(
       trackedFilters
     );
+  });
+
+  it('passes transformRuleContexts', () => {
+    const transformRuleContexts = 'transformRuleContexts';
+    const template = `<ais-query-rule-context
+      [transformRuleContexts]="'${transformRuleContexts}'"
+    >
+    </ais-query-rule-context>`;
+    const state = {};
+
+    render(template, state);
+
     expect(createWidget.mock.calls[0][1].transformRuleContexts).toEqual(
       transformRuleContexts
     );

--- a/src/query-rule-context/query-rule-context.module.ts
+++ b/src/query-rule-context/query-rule-context.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { NgAisQueryRuleContext } from './query-rule-context';
+
+@NgModule({
+  declarations: [NgAisQueryRuleContext],
+  entryComponents: [NgAisQueryRuleContext],
+  exports: [NgAisQueryRuleContext],
+  imports: [CommonModule],
+})
+export class NgAisQueryRuleContextModule {}

--- a/src/query-rule-context/query-rule-context.ts
+++ b/src/query-rule-context/query-rule-context.ts
@@ -4,7 +4,7 @@ import { connectQueryRules } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 
-type FacetValue = string | number;
+type FacetValue = string | number | boolean;
 
 @Component({
   selector: 'ais-query-rule-context',

--- a/src/query-rule-context/query-rule-context.ts
+++ b/src/query-rule-context/query-rule-context.ts
@@ -12,7 +12,7 @@ type FacetValue = string | number | boolean;
 })
 export class NgAisQueryRuleContext extends BaseWidget {
   @Input() public trackedFilters?: {
-    [facetName: string]: (facetValues: FacetValue[]) => FacetValue[];
+    [facetName: string]: (facetValues?: FacetValue[]) => FacetValue[];
   };
   @Input() public transformRuleContexts?: (items: string[]) => string[];
 

--- a/src/query-rule-context/query-rule-context.ts
+++ b/src/query-rule-context/query-rule-context.ts
@@ -11,7 +11,7 @@ type FacetValue = string | number | boolean;
   template: '',
 })
 export class NgAisQueryRuleContext extends BaseWidget {
-  @Input() public trackedFilters?: {
+  @Input() public trackedFilters: {
     [facetName: string]: (facetValues?: FacetValue[]) => FacetValue[];
   };
   @Input() public transformRuleContexts?: (items: string[]) => string[];

--- a/src/query-rule-context/query-rule-context.ts
+++ b/src/query-rule-context/query-rule-context.ts
@@ -1,0 +1,34 @@
+import { Component, Input, Inject, forwardRef } from '@angular/core';
+
+import { connectQueryRules } from 'instantsearch.js/es/connectors';
+import { BaseWidget } from '../base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
+
+type FacetValue = string | number;
+
+@Component({
+  selector: 'ais-query-rule-context',
+  template: '',
+})
+export class NgAisQueryRuleContext extends BaseWidget {
+  @Input() public trackedFilters?: {
+    [facetName: string]: (facetValues: FacetValue[]) => FacetValue[];
+  };
+  @Input() public transformRuleContexts?: (items: string[]) => string[];
+
+  constructor(
+    @Inject(forwardRef(() => NgAisInstantSearch))
+    public instantSearchParent: any
+  ) {
+    super('QueryRuleContext');
+  }
+
+  public ngOnInit() {
+    this.createWidget(connectQueryRules, {
+      trackedFilters: this.trackedFilters,
+      transformRuleContexts: this.transformRuleContexts,
+    });
+
+    super.ngOnInit();
+  }
+}

--- a/src/query-rule-context/query-rule-context.ts
+++ b/src/query-rule-context/query-rule-context.ts
@@ -11,8 +11,9 @@ type FacetValue = string | number | boolean;
   template: '',
 })
 export class NgAisQueryRuleContext extends BaseWidget {
-  @Input() public trackedFilters: {
-    [facetName: string]: (facetValues?: FacetValue[]) => FacetValue[];
+  @Input()
+  public trackedFilters: {
+    [facetName: string]: (facetValues: FacetValue[]) => FacetValue[];
   };
   @Input() public transformRuleContexts?: (items: string[]) => string[];
 

--- a/src/refinement-list/__tests__/refinement-list.spec.ts
+++ b/src/refinement-list/__tests__/refinement-list.spec.ts
@@ -55,7 +55,7 @@ describe('RefinementList', () => {
       expect(createWidget.mock.calls[0][0]).toEqual(connectRefinementList);
     });
     it('should be called with attributeName undefined by default', () => {
-      render(`<ais-refinement-list></ais-refinement-list>\``);
+      render(`<ais-refinement-list></ais-refinement-list>`);
       expect(createWidget.mock.calls[0][1].attribute).toBeUndefined();
     });
     it('should be called with attributeName passed down by attribute prop', () => {


### PR DESCRIPTION
This adds the `ais-query-rule-context` widget based on the InstantSearch.js `queryRules` connector.

This depends on #482.