### PR TITLE
fix(Hits): add test for template support

### DIFF
--- a/src/hits/__tests__/__snapshots__/hits.spec.ts.snap
+++ b/src/hits/__tests__/__snapshots__/hits.spec.ts.snap
@@ -191,3 +191,57 @@ exports[`Hits should apply \`transformItems\` if specified 1`] = `
   </ais-instantsearch>
 </ng-component>
 `;
+
+exports[`Hits should expose hits to the passed template 1`] = `
+<ng-component
+  testedWidget={[Function NgAisHits]}
+>
+  <ais-instantsearch>
+    <ais-hits>
+      <div
+        class="ais-Hits"
+      >
+        
+        <ul>
+          
+          <li>
+             foo 
+          </li>
+          <li>
+             bar 
+          </li>
+          <li>
+             foobar 
+          </li>
+          <li>
+             barfoo 
+          </li>
+        </ul>
+        
+      </div>
+    </ais-hits>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`Hits should expose results to the passed template 1`] = `
+<ng-component
+  testedWidget={[Function NgAisHits]}
+>
+  <ais-instantsearch>
+    <ais-hits>
+      <div
+        class="ais-Hits"
+      >
+        
+         {
+    "nbPages": 50,
+    "page": 0,
+    "hitsPerPage": 20
+  } 
+        
+      </div>
+    </ais-hits>
+  </ais-instantsearch>
+</ng-component>
+`;

--- a/src/hits/__tests__/hits.spec.ts
+++ b/src/hits/__tests__/hits.spec.ts
@@ -4,38 +4,87 @@ import { NgAisHighlight } from '../../highlight/highlight';
 
 const defaultState = {
   hits: [
-    { name: 'foo', description: 'foo' },
-    { name: 'bar', description: 'bar' },
-    { name: 'foobar', description: 'foobar' },
-    { name: 'barfoo', description: 'barfoo' },
+    { objectID: '1', name: 'foo', description: 'foo' },
+    { objectID: '2', name: 'bar', description: 'bar' },
+    { objectID: '3', name: 'foobar', description: 'foobar' },
+    { objectID: '4', name: 'barfoo', description: 'barfoo' },
   ],
-  results: {},
+  results: { nbPages: 50, page: 0, hitsPerPage: 20 },
 };
-
-const render = createRenderer({
-  defaultState,
-  template: '<ais-hits></ais-hits>',
-  TestedWidget: NgAisHits,
-  additionalDeclarations: [NgAisHighlight],
-});
 
 describe('Hits', () => {
   it('renders markup without state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hits></ais-hits>',
+      TestedWidget: NgAisHits,
+      additionalDeclarations: [NgAisHighlight],
+    });
     const fixture = render();
     expect(fixture).toMatchSnapshot();
   });
 
   it('renders markup with state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hits></ais-hits>',
+      TestedWidget: NgAisHits,
+      additionalDeclarations: [NgAisHighlight],
+    });
     const fixture = render({});
     expect(fixture).toMatchSnapshot();
   });
 
   it('should apply `transformItems` if specified', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hits></ais-hits>',
+      TestedWidget: NgAisHits,
+      additionalDeclarations: [NgAisHighlight],
+    });
     const fixture = render({});
     fixture.componentInstance.testedWidget.transformItems = items =>
       items.map(item => ({ ...item, name: `transformed - ${item.name}` }));
     fixture.componentInstance.testedWidget.updateState(defaultState, false);
     fixture.detectChanges();
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should expose hits to the passed template', () => {
+    const render = createRenderer({
+      defaultState,
+      template: `
+          <ais-hits>
+            <ng-template let-hits="hits">
+              <ul>
+                <li *ngFor="let hit of hits">
+                  {{hit.name}}
+                </li>
+              </ul>
+            </ng-template>
+          </ais-hits>
+        `,
+      TestedWidget: NgAisHits,
+      additionalDeclarations: [NgAisHighlight],
+    });
+    const fixture = render({});
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should expose results to the passed template', () => {
+    const render = createRenderer({
+      defaultState,
+      template: `
+          <ais-hits>
+            <ng-template let-results="results">
+              {{ results | json }}
+            </ng-template>
+          </ais-hits>
+        `,
+      TestedWidget: NgAisHits,
+      additionalDeclarations: [NgAisHighlight],
+    });
+    const fixture = render({});
     expect(fixture).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This PR adds tests for make sure `ais-hits` works with `<ng-template>`
and that it's passing `hits` and `results` like we want to.

This is a fairly common use case and yet we do not test it.
I noticed this as I was attempting to write tests for the insights
integration.
