### PR TITLE
feat(insights): add insights support to Hits widget

### DIFF
--- a/examples/storybook/src/stories/Hits.stories.ts
+++ b/examples/storybook/src/stories/Hits.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/angular';
+import { action } from '@storybook/addon-actions';
 import { wrapWithHits } from '../wrap-with-hits';
 import meta from '../meta';
 
@@ -22,5 +23,30 @@ storiesOf('Hits', module)
         </ng-template>
       </ais-hits>
       `,
+    }),
+  }))
+  .add('with insights', () => ({
+    component: wrapWithHits({
+      template: `
+      <ais-hits>
+        <ng-template let-hits="hits" let-insights="insights">
+          <div *ngFor="let hit of hits">
+            Hit {{hit.objectID}}:
+            <ais-highlight attribute="name" [hit]="hit">
+            </ais-highlight>
+            
+            <button (click)="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [hit.objectID] })">
+              Add to favorite
+            </button>
+          </div>
+        </ng-template>
+      </ais-hits>
+      `,
+      insightsClient: (method: string, payload: any) => {
+        action(`[InsightsClient] sent ${method} with payload`)(payload);
+      },
+      searchParameters: {
+        clickAnalytics: true,
+      },
     }),
   }));

--- a/examples/storybook/src/wrap-with-hits.ts
+++ b/examples/storybook/src/wrap-with-hits.ts
@@ -13,6 +13,8 @@ type WrapWithHitsParams = {
   methods?: {};
   searchFunction?: (helper: Helper) => void;
   searchClient?: {};
+  // TODO: update with InstantSearch.js types
+  insightsClient?: (method: string, payload: object) => void;
   indexName?: string;
   appId?: string;
   apiKey?: string;
@@ -50,6 +52,7 @@ export function wrapWithHits({
   searchParameters = {},
   methods = {},
   searchFunction,
+  insightsClient,
   indexName = 'instant_search',
   appId = 'latency',
   apiKey = '6be0576ff61c053d5f9a3225e2a90f76',
@@ -83,6 +86,7 @@ export function wrapWithHits({
   class AppComponent {
     config = {
       searchClient: algoliasearch(appId, apiKey),
+      insightsClient,
       indexName,
       searchFunction,
       searchParameters: {

--- a/src/hits/__tests__/hits.spec.ts
+++ b/src/hits/__tests__/hits.spec.ts
@@ -87,4 +87,39 @@ describe('Hits', () => {
     const fixture = render({});
     expect(fixture).toMatchSnapshot();
   });
+  it('should allow calling insightsClient', () => {
+    const render = createRenderer({
+      defaultState,
+      template: `
+          <ais-hits>
+            <ng-template let-hits="hits" let-insights="insights">
+              <ul>
+                <li *ngFor="let hit of hits">
+                  <button 
+                    id="add-to-cart-{{hit.objectID}}" 
+                    (click)="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [hit.objectID] })">
+                    
+                  </button>
+                </li>
+              </ul>
+            </ng-template>
+          </ais-hits>
+        `,
+      TestedWidget: NgAisHits,
+      additionalDeclarations: [NgAisHighlight],
+    });
+
+    const insights = jest.fn();
+    const fixture = render({ insights });
+
+    const button = fixture.debugElement.nativeElement.querySelector(
+      '#add-to-cart-2'
+    );
+    button.click();
+
+    expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
+      eventName: 'Add to cart',
+      objectIDs: ['2'],
+    });
+  });
 });

--- a/src/hits/hits.ts
+++ b/src/hits/hits.ts
@@ -7,7 +7,7 @@ import {
   forwardRef,
 } from '@angular/core';
 
-import { connectHits } from 'instantsearch.js/es/connectors';
+import { connectHitsWithInsights } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 
@@ -46,7 +46,7 @@ export class NgAisHits extends BaseWidget {
     public instantSearchParent: any
   ) {
     super('Hits');
-    this.createWidget(connectHits, { escapeHits: true });
+    this.createWidget(connectHitsWithInsights, { escapeHits: true });
   }
 
   updateState = (state, isFirstRendering: boolean) => {


### PR DESCRIPTION
**Summary**

This integrates insights with Angular Instantsearch to help using Click Analytics in Hits.

Using `connectHitsWithInsights` instead of `connectHits` exposed a new property `insights` to the internal state, which user can call to emit insights events.

**Result**

```html
<ais-hits>
    <ng-template let-hits="hits" let-insights="insights">
      <div *ngFor="let hit of hits">
        <ais-highlight attribute="name" [hit]="hit"></ais-highlight>

        <button (click)="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [hit.objectID] })">
          Add to favorite
        </button>
      </div>
    </ng-template>
</ais-hits>
```

