### PR TITLE
feat(insights): add insights support to InfiniteHits widget

### DIFF
--- a/examples/storybook/src/stories/InfiniteHits.stories.ts
+++ b/examples/storybook/src/stories/InfiniteHits.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/angular';
+import { action } from '@storybook/addon-actions';
 import { wrapWithHits } from '../wrap-with-hits';
 import { MemoryRouter } from '../MemoryRouter';
 import meta from '../meta';
@@ -36,6 +37,32 @@ storiesOf('InfiniteHits', module)
       template: '<ais-infinite-hits [showPrevious]=true></ais-infinite-hits>',
       routing: {
         router: new MemoryRouter({ page: 3 }),
+      },
+    }),
+  }))
+  .add('with insights', () => ({
+    component: wrapWithHits({
+      template: `
+      <ais-infinite-hits>
+        <ng-template let-hits="hits" let-showMore="showMore" let-insights="insights">
+          <div *ngFor="let hit of hits">
+            Hit {{hit.objectID}}:
+            <ais-highlight attribute="name" [hit]="hit">
+            </ais-highlight>
+            
+            <button (click)="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [hit.objectID] })">
+              Add to favorite
+            </button>
+          </div>
+          <button (click)="showMore()">Load more</button>
+        </ng-template>
+      </ais-infinite-hits>
+      `,
+      insightsClient: (method: string, payload: any) => {
+        action(`[InsightsClient] sent ${method} with payload`)(payload);
+      },
+      searchParameters: {
+        clickAnalytics: true,
       },
     }),
   }));

--- a/src/infinite-hits/__tests__/__snapshots__/infinite-hits.spec.ts.snap
+++ b/src/infinite-hits/__tests__/__snapshots__/infinite-hits.spec.ts.snap
@@ -124,6 +124,48 @@ exports[`InfiniteHits renders markup without state 1`] = `
 </ng-component>
 `;
 
+exports[`InfiniteHits should allow calling insightsClient 1`] = `
+<ng-component
+  testedWidget={[Function NgAisInfiniteHits]}
+>
+  <ais-instantsearch>
+    <ais-infinite-hits>
+      <div
+        class="ais-InfiniteHits"
+      >
+        
+        <ul>
+          
+          <li>
+            <button
+              id="add-to-cart-1"
+            />
+          </li>
+          <li>
+            <button
+              id="add-to-cart-2"
+            />
+          </li>
+          <li>
+            <button
+              id="add-to-cart-3"
+            />
+          </li>
+          <li>
+            <button
+              id="add-to-cart-4"
+            />
+          </li>
+        </ul>
+        
+        
+        
+      </div>
+    </ais-infinite-hits>
+  </ais-instantsearch>
+</ng-component>
+`;
+
 exports[`InfiniteHits should disable \`showMore\` button 1`] = `
 <ng-component
   testedWidget={[Function NgAisInfiniteHits]}

--- a/src/infinite-hits/__tests__/infinite-hits.spec.ts
+++ b/src/infinite-hits/__tests__/infinite-hits.spec.ts
@@ -4,10 +4,10 @@ import { NgAisHighlight } from '../../highlight/highlight';
 
 const defaultState = {
   hits: [
-    { name: 'foo', description: 'foo' },
-    { name: 'bar', description: 'bar' },
-    { name: 'foobar', description: 'foobar' },
-    { name: 'barfoo', description: 'barfoo' },
+    { objectID: '1', name: 'foo', description: 'foo' },
+    { objectID: '2', name: 'bar', description: 'bar' },
+    { objectID: '3', name: 'foobar', description: 'foobar' },
+    { objectID: '4', name: 'barfoo', description: 'barfoo' },
   ],
   showMore: jest.fn(),
   isLastPage: false,
@@ -160,5 +160,44 @@ describe('InfiniteHits', () => {
     const fixture = renderWithCustomTemplate({});
 
     expect(fixture).toMatchSnapshot();
+  });
+
+  it('should allow calling insightsClient', () => {
+    const renderWithCustomTemplate = createRenderer({
+      defaultState,
+      template: `
+        <ais-infinite-hits>
+          <ng-template
+            let-hits="hits"
+            let-insights="insights"
+          >
+            <ul>
+              <li *ngFor="let hit of hits">
+                <button 
+                  id="add-to-cart-{{hit.objectID}}" 
+                  (click)="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [hit.objectID] })">
+                  
+                </button>
+              </li>
+            </ul>
+          </ng-template>
+        </ais-infinite-hits>
+      `,
+      TestedWidget: NgAisInfiniteHits,
+      additionalDeclarations: [NgAisHighlight],
+    });
+    const insights = jest.fn();
+    const fixture = renderWithCustomTemplate({ insights });
+    expect(fixture).toMatchSnapshot();
+
+    const button = fixture.debugElement.nativeElement.querySelector(
+      '#add-to-cart-2'
+    );
+    button.click();
+
+    expect(insights).toHaveBeenCalledWith('clickedObjectIDsAfterSearch', {
+      eventName: 'Add to cart',
+      objectIDs: ['2'],
+    });
   });
 });

--- a/src/infinite-hits/infinite-hits.ts
+++ b/src/infinite-hits/infinite-hits.ts
@@ -7,7 +7,7 @@ import {
   forwardRef,
 } from '@angular/core';
 
-import { connectInfiniteHits } from 'instantsearch.js/es/connectors';
+import { connectInfiniteHitsWithInsights } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { noop } from '../utils';
@@ -82,7 +82,7 @@ export class NgAisInfiniteHits extends BaseWidget {
     public instantSearchParent: any
   ) {
     super('InfiniteHits');
-    this.createWidget(connectInfiniteHits, { escapeHits: true });
+    this.createWidget(connectInfiniteHitsWithInsights, { escapeHits: true });
   }
 
   public showMoreHandler(event: MouseEvent) {


### PR DESCRIPTION
⚠️  This PR can't work until https://github.com/algolia/angular-instantsearch/pull/492 and https://github.com/algolia/angular-instantsearch/pull/491 are merged. It will stay as draft until then.


**Summary**

This integrates insights with Angular Instantsearch to help using Click Analytics in InfiniteHits.

Using `connectInfiniteHitsWithInsights` instead of `connectInfiniteHits` exposed a new property `insights` to the internal state, which user can call to emit insights events.


**Result**

```html
<ais-infinite-hits>
    <ng-template let-hits="hits" let-insights="insights">
      <div *ngFor="let hit of hits">
        <ais-highlight attribute="name" [hit]="hit"></ais-highlight>

        <button (click)="insights('clickedObjectIDsAfterSearch', { eventName: 'Add to cart', objectIDs: [hit.objectID] })">
          Add to favorite
        </button>
      </div>
    </ng-template>
</ais-infinite-hits>
```

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->



<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->



<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
