### PR TITLE
fix(RangeInput): allow precision of 0

### DIFF
--- a/examples/storybook/src/stories/RangeInput.stories.ts
+++ b/examples/storybook/src/stories/RangeInput.stories.ts
@@ -11,4 +11,20 @@ storiesOf('RangeInput', module)
       </ais-range-input>
     `,
     }),
+  }))
+  .add('precision 0', () => ({
+    component: wrapWithHits({
+      template: `
+      <ais-range-input attribute="price" precision="0">
+      </ais-range-input>
+    `,
+    }),
+  }))
+  .add('precision -2', () => ({
+    component: wrapWithHits({
+      template: `
+        <ais-range-input attribute="price" precision="-2">
+        </ais-range-input>
+      `,
+    }),
   }));

--- a/src/range-input/__tests__/__snapshots__/range-input.spec.ts.snap
+++ b/src/range-input/__tests__/__snapshots__/range-input.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`RangeInput renders markup with state 1`] = `
               max="100"
               min="0"
               placeholder="0"
-              step="0.01"
+              step="1"
               type="number"
             />
           </label>
@@ -48,7 +48,7 @@ exports[`RangeInput renders markup with state 1`] = `
               max="100"
               min="0"
               placeholder="100"
-              step="0.01"
+              step="1"
               type="number"
             />
           </label>
@@ -90,7 +90,7 @@ exports[`RangeInput renders markup without state 1`] = `
               max="undefined"
               min="undefined"
               placeholder="undefined"
-              step="0.01"
+              step="1"
               type="number"
             />
           </label>
@@ -112,7 +112,7 @@ exports[`RangeInput renders markup without state 1`] = `
               max="undefined"
               min="undefined"
               placeholder="undefined"
-              step="0.01"
+              step="1"
               type="number"
             />
           </label>

--- a/src/range-input/__tests__/range-input.spec.ts
+++ b/src/range-input/__tests__/range-input.spec.ts
@@ -83,14 +83,14 @@ describe('RangeInput', () => {
     expect(refine).toHaveBeenCalledWith([20, 50]);
   });
 
-  it('should apply precision of 2 by default', () => {
+  it('should apply precision of 0 by default', () => {
     const render = createRenderer({
       defaultState,
       template: '<ais-range-input></ais-range-input>',
       TestedWidget: NgAisRangeInput,
     });
     const fixture = render();
-    expect(fixture.componentInstance.testedWidget.step).toEqual(0.01);
+    expect(fixture.componentInstance.testedWidget.step).toEqual(1);
   });
 
   it('should allow precision of 0', () => {

--- a/src/range-input/__tests__/range-input.spec.ts
+++ b/src/range-input/__tests__/range-input.spec.ts
@@ -7,24 +7,33 @@ const defaultState = {
   refine: jest.fn(),
 };
 
-const render = createRenderer({
-  defaultState,
-  template: '<ais-range-input></ais-range-input>',
-  TestedWidget: NgAisRangeInput,
-});
-
 describe('RangeInput', () => {
   it('renders markup without state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
     const fixture = render();
     expect(fixture).toMatchSnapshot();
   });
 
   it('renders markup with state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
     const fixture = render({});
     expect(fixture).toMatchSnapshot();
   });
 
   it('should update `min/max InputValue`', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
     const fixture = render({});
 
     const [
@@ -42,7 +51,12 @@ describe('RangeInput', () => {
     expect(fixture.componentInstance.testedWidget.maxInputValue).toBe(50);
   });
 
-  it('should call renfine when submitting form', () => {
+  it('should call refine when submitting form', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
     const refine = jest.fn();
     const fixture = render({ refine });
 
@@ -67,5 +81,45 @@ describe('RangeInput', () => {
 
     expect(refine).toHaveBeenCalled();
     expect(refine).toHaveBeenCalledWith([20, 50]);
+  });
+
+  it('should apply precision of 2 by default', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
+    const fixture = render();
+    expect(fixture.componentInstance.testedWidget.step).toEqual(0.01);
+  });
+
+  it('should allow precision of 0', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input precision="0"></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
+    const fixture = render();
+    expect(fixture.componentInstance.testedWidget.step).toEqual(1);
+  });
+
+  it('should allow precision of 1', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input precision="1"></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
+    const fixture = render();
+    expect(fixture.componentInstance.testedWidget.step).toEqual(0.1);
+  });
+
+  it('should allow precision of -2', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input precision="-2"></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
+    const fixture = render();
+    expect(fixture.componentInstance.testedWidget.step).toEqual(100);
   });
 });

--- a/src/range-input/range-input.ts
+++ b/src/range-input/range-input.ts
@@ -70,7 +70,7 @@ export class NgAisRangeInput extends BaseWidget {
   @Input() public attribute: string;
   @Input() public min?: number;
   @Input() public max?: number;
-  @Input() public precision?: number = 2;
+  @Input() public precision?: number = 0;
 
   // inner state
   public minInputValue?: number | string = '';

--- a/src/range-input/range-input.ts
+++ b/src/range-input/range-input.ts
@@ -77,7 +77,10 @@ export class NgAisRangeInput extends BaseWidget {
   public maxInputValue?: number | string = '';
 
   get step() {
-    const precision = parseNumberInput(this.precision) || 2;
+    const precision =
+      typeof this.precision !== 'undefined'
+        ? parseNumberInput(this.precision)
+        : 2;
     return 1 / Math.pow(10, precision);
   }
 

--- a/src/range-input/range-input.ts
+++ b/src/range-input/range-input.ts
@@ -70,17 +70,14 @@ export class NgAisRangeInput extends BaseWidget {
   @Input() public attribute: string;
   @Input() public min?: number;
   @Input() public max?: number;
-  @Input() public precision?: number;
+  @Input() public precision?: number = 2;
 
   // inner state
   public minInputValue?: number | string = '';
   public maxInputValue?: number | string = '';
 
   get step() {
-    const precision =
-      typeof this.precision !== 'undefined'
-        ? parseNumberInput(this.precision)
-        : 2;
+    const precision = parseNumberInput(this.precision);
     return 1 / Math.pow(10, precision);
   }
 


### PR DESCRIPTION
**Summary**

Prior to this fix it was not possible to use precision 0

```html
<ais-range-input attribute="price" precision="0"></ais-range-input>
```

And so it was not possible to produce steps of size `1`.

Closes https://github.com/algolia/angular-instantsearch/issues/374
