### PR TITLE
 feat(searchClient): enforce search client

### DIFF
--- a/examples/angular-router/package.json
+++ b/examples/angular-router/package.json
@@ -17,6 +17,7 @@
     "@angular/platform-browser": "7.0.1",
     "@angular/platform-browser-dynamic": "7.0.1",
     "@angular/router": "7.0.1",
+    "algoliasearch": "3.32.1",
     "angular-instantsearch": "3.0.0-beta.0",
     "core-js": "2.4.1",
     "instantsearch.js": "3.4.0",

--- a/examples/angular-router/src/app/components/search/search.component.ts
+++ b/examples/angular-router/src/app/components/search/search.component.ts
@@ -1,16 +1,10 @@
 import { Component, OnDestroy } from '@angular/core';
+import algoliasearch from 'algoliasearch/lite';
 
 @Component({
   selector: 'app-search',
   template: `
-    <ais-instantsearch
-      [config]="{
-        appId: 'latency',
-        apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-        indexName: 'instant_search',
-        routing: true
-      }"
-    >
+    <ais-instantsearch [config]="config">
       <div class="jumbotron">
         <p class="text-center">
           <ais-search-box placeholder="Search a product"></ais-search-box>
@@ -65,6 +59,12 @@ import { Component, OnDestroy } from '@angular/core';
   styles: [],
 })
 export class SearchComponent implements OnDestroy {
+  config = {
+    searchClient: algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76'),
+    indexName: 'instant_search',
+    routing: true,
+  };
+
   ngOnDestroy() {
     console.log('SearchComponent::ngOnDestroy');
   }

--- a/examples/angular-router/yarn.lock
+++ b/examples/angular-router/yarn.lock
@@ -490,6 +490,27 @@ algoliasearch-helper@^2.26.1:
     qs "^6.5.1"
     util "^0.10.3"
 
+algoliasearch@3.32.1:
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.32.1.tgz#605f8a2c17ab8da2af4456110f4d0a02b384e3d0"
+  integrity sha512-NaaHMboU9tKwrU3aim7LlzSDqKb+1TGaC+Lx3NOttSnuMHbPpaf+7LtJL4KlosbRWEwqb9t5wSYMVDrPTH2dNA==
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.9"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
+
 algoliasearch@^3.29.0:
   version "3.30.0"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.30.0.tgz#355585e49b672e5f71d45b9c2b371ecdff129cd1"
@@ -1681,7 +1702,7 @@ debug@*:
   dependencies:
     ms "^2.1.1"
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==

--- a/examples/e-commerce/package.json
+++ b/examples/e-commerce/package.json
@@ -17,6 +17,7 @@
     "@angular/platform-browser": "7.0.1",
     "@angular/platform-browser-dynamic": "7.0.1",
     "@angular/router": "7.0.1",
+    "algoliasearch": "3.32.1",
     "angular-instantsearch": "3.0.0-beta.0",
     "core-js": "2.4.1",
     "instantsearch.js": "3.1.1",

--- a/examples/e-commerce/src/app/app.component.html
+++ b/examples/e-commerce/src/app/app.component.html
@@ -1,11 +1,5 @@
 <div class="container-fluid">
-  <ais-instantsearch
-    [config]="{
-      appId: 'latency',
-      apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-      indexName: 'instant_search'
-    }"
-  >
+  <ais-instantsearch [config]="config">
     <header class="content-wrapper">
       <a href="./" class="logo">amazing</a>
       <ais-search-box placeholder="Search a product"></ais-search-box>
@@ -13,15 +7,17 @@
 
     <div class="content-wrapper">
       <aside>
-        <ais-clear-refinements
-          buttonLabel="Clear all filters"
-        >
+        <ais-clear-refinements buttonLabel="Clear all filters">
         </ais-clear-refinements>
 
         <section class="facet-wrapper">
           <div class="facet-category-title">Show results for</div>
           <ais-hierarchical-menu
-            [attributes]="['hierarchicalCategories.lvl0', 'hierarchicalCategories.lvl1', 'hierarchicalCategories.lvl2']"
+            [attributes]="[
+              'hierarchicalCategories.lvl0',
+              'hierarchicalCategories.lvl1',
+              'hierarchicalCategories.lvl2'
+            ]"
             [sortBy]="['name:asc']"
           >
           </ais-hierarchical-menu>
@@ -30,20 +26,12 @@
         <section class="facet-wrapper">
           <div class="facet-category-title">Refine by</div>
           <ais-panel header="Materials">
-            <ais-refinement-list
-              attribute="type"
-              operator="or"
-              limit="10"
-            >
+            <ais-refinement-list attribute="type" operator="or" limit="10">
             </ais-refinement-list>
           </ais-panel>
 
           <ais-panel header="Colors">
-            <ais-refinement-list
-              attribute="brand"
-              operator="or"
-              limit="10"
-            >
+            <ais-refinement-list attribute="brand" operator="or" limit="10">
             </ais-refinement-list>
           </ais-panel>
 
@@ -52,10 +40,7 @@
           </ais-panel>
 
           <ais-panel header="Prices">
-            <ais-range-input
-              header="Prices"
-              attribute="price"
-            >
+            <ais-range-input header="Prices" attribute="price">
             </ais-range-input>
           </ais-panel>
         </section>
@@ -66,84 +51,69 @@
       </aside>
 
       <div class="results-wrapper">
-      <section id="results-topbar">
-        <ais-panel header="Sort by">
-          <ais-sort-by
-            [items]="
-              [
-                {value: 'instant_search', label: 'Featured'},
-                {value: 'instant_search_price_asc', label: 'Price asc.'},
-                {value: 'instant_search_price_desc', label: 'Price desc.'}
-              ]
-            "
-          >
-          </ais-sort-by>
-        </ais-panel>
-        <ais-stats></ais-stats>
-      </section>
-
-      <main>
-        <ais-hits
-          [transformItems]="transformHits"
-        >
-          <ng-template
-            let-hits="hits"
-            let-results="results"
-          >
-            <div
-              *ngIf="hits.length === 0"
-              class="text-center"
+        <section id="results-topbar">
+          <ais-panel header="Sort by">
+            <ais-sort-by
+              [items]="[
+                { value: 'instant_search', label: 'Featured' },
+                { value: 'instant_search_price_asc', label: 'Price asc.' },
+                { value: 'instant_search_price_desc', label: 'Price desc.' }
+              ]"
             >
-              No results found matching <strong>{{results.query}}</strong>.
-            </div>
+            </ais-sort-by>
+          </ais-panel>
+          <ais-stats></ais-stats>
+        </section>
 
-            <article
-              *ngFor="let hit of hits; trackBy: trackByObjectID"
-              class="hit"
-            >
-              <div class="product-picture-wrapper">
-                <div class="product-picture">
-                  <app-product-image [src]="hit.image"></app-product-image>
-                </div>
+        <main>
+          <ais-hits [transformItems]="transformHits">
+            <ng-template let-hits="hits" let-results="results">
+              <div *ngIf="hits.length === 0" class="text-center">
+                No results found matching <strong>{{ results.query }}</strong
+                >.
               </div>
 
-              <div class="product-desc-wrapper">
-                <div class="product-name">
-                  <ais-highlight
-                    attribute="name"
-                    [hit]="hit"
-                  >
-                  </ais-highlight>
+              <article
+                *ngFor="let hit of hits; trackBy: trackByObjectID"
+                class="hit"
+              >
+                <div class="product-picture-wrapper">
+                  <div class="product-picture">
+                    <app-product-image [src]="hit.image"></app-product-image>
+                  </div>
                 </div>
 
-                <div class="product-type">
-                  <ais-highlight
-                    attribute="type"
-                    [hit]="hit"
-                  >
-                  </ais-highlight>
-                </div>
+                <div class="product-desc-wrapper">
+                  <div class="product-name">
+                    <ais-highlight attribute="name" [hit]="hit">
+                    </ais-highlight>
+                  </div>
 
-                <div class="product-price">${{hit.price}}</div>
-                <div class="product-rating">
-                  <i
-                    *ngFor="let star of hit.stars"
-                    [ngClass]="{
-                      'fa': true,
-                      'fa-star': star,
-                      'fa-star-o': !star
-                    }"
-                  >
-                  </i>
-                </div>
-              </div>
-            </article>
-          </ng-template>
-        </ais-hits>
-      </main>
+                  <div class="product-type">
+                    <ais-highlight attribute="type" [hit]="hit">
+                    </ais-highlight>
+                  </div>
 
-      <ais-pagination></ais-pagination>
-    </div>
+                  <div class="product-price">${{ hit.price }}</div>
+                  <div class="product-rating">
+                    <i
+                      *ngFor="let star of hit.stars"
+                      [ngClass]="{
+                        fa: true,
+                        'fa-star': star,
+                        'fa-star-o': !star
+                      }"
+                    >
+                    </i>
+                  </div>
+                </div>
+              </article>
+            </ng-template>
+          </ais-hits>
+        </main>
+
+        <ais-pagination></ais-pagination>
+      </div>
     </div>
   </ais-instantsearch>
 </div>

--- a/examples/e-commerce/src/app/app.component.ts
+++ b/examples/e-commerce/src/app/app.component.ts
@@ -1,10 +1,16 @@
 import { Component } from '@angular/core';
+import algoliasearch from 'algoliasearch/lite';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
 })
 export class AppComponent {
+  config = {
+    searchClient: algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76'),
+    indexName: 'instant_search',
+  };
+
   trackByObjectID(index, hit) {
     return hit.objectID;
   }

--- a/examples/e-commerce/yarn.lock
+++ b/examples/e-commerce/yarn.lock
@@ -481,6 +481,27 @@ algoliasearch-helper@^2.26.0, algoliasearch-helper@^2.26.1:
     qs "^6.5.1"
     util "^0.10.3"
 
+algoliasearch@3.32.1:
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.32.1.tgz#605f8a2c17ab8da2af4456110f4d0a02b384e3d0"
+  integrity sha512-NaaHMboU9tKwrU3aim7LlzSDqKb+1TGaC+Lx3NOttSnuMHbPpaf+7LtJL4KlosbRWEwqb9t5wSYMVDrPTH2dNA==
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.9"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
+
 algoliasearch@^3.29.0:
   version "3.30.0"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.30.0.tgz#355585e49b672e5f71d45b9c2b371ecdff129cd1"
@@ -1672,7 +1693,7 @@ debug@*:
   dependencies:
     ms "^2.1.1"
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==

--- a/examples/media/package.json
+++ b/examples/media/package.json
@@ -17,6 +17,7 @@
     "@angular/platform-browser": "7.0.1",
     "@angular/platform-browser-dynamic": "7.0.1",
     "@angular/router": "7.0.1",
+    "algoliasearch": "3.32.1",
     "angular-instantsearch": "3.0.0-beta.0",
     "core-js": "2.4.1",
     "instantsearch.js": "3.4.0",

--- a/examples/media/src/app/app.component.html
+++ b/examples/media/src/app/app.component.html
@@ -1,15 +1,7 @@
-<ais-instantsearch
-  [config]="{
-    appId: 'latency',
-    apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-    indexName: 'movies'
-  }"
->
+<ais-instantsearch [config]="config">
   <header class="row">
     <div>
-      <a href="#" class="logo">
-        You <i class="fa fa-youtube-play"></i>
-      </a>
+      <a href="#" class="logo"> You <i class="fa fa-youtube-play"></i> </a>
     </div>
 
     <div class="searchbox-container">
@@ -23,9 +15,7 @@
     <aside>
       <ul class="nav nav-list">
         <li>
-          <a href="#">
-            <i class="fa fa-home"></i> Home
-          </a>
+          <a href="#"> <i class="fa fa-home"></i> Home </a>
         </li>
         <li class="separator"></li>
       </ul>
@@ -53,7 +43,7 @@
         <ais-stats></ais-stats>
       </div>
 
-      <hr>
+      <hr />
 
       <!-- Hits -->
       <ais-hits [transformItems]="transformHits">
@@ -69,7 +59,7 @@
                 <i
                   *ngFor="let star of hit.stars"
                   [ngClass]="{
-                    'fa': true,
+                    fa: true,
                     'fa-star': star,
                     'fa-star-o': !star
                   }"
@@ -77,14 +67,14 @@
                 </i>
               </h4>
 
-              <p class="year">{{hit.year}}</p>
+              <p class="year">{{ hit.year }}</p>
               <div class="genre">
                 <span
                   class="badge"
                   *ngFor="let genre of hit.genre"
                   style="margin-right: 5px;"
                 >
-                  {{genre}}
+                  {{ genre }}
                 </span>
               </div>
             </div>

--- a/examples/media/src/app/app.component.ts
+++ b/examples/media/src/app/app.component.ts
@@ -1,10 +1,16 @@
 import { Component } from '@angular/core';
+import algoliasearch from 'algoliasearch/lite';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
 })
 export class AppComponent {
+  config = {
+    searchClient: algoliasearch('latency', '6be0576ff61c053d5f9a3225e2a90f76'),
+    indexName: 'movies',
+  };
+
   transformHits(hits) {
     hits.forEach(hit => {
       hit.stars = [];

--- a/examples/media/yarn.lock
+++ b/examples/media/yarn.lock
@@ -490,6 +490,27 @@ algoliasearch-helper@^2.26.1:
     qs "^6.5.1"
     util "^0.10.3"
 
+algoliasearch@3.32.1:
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.32.1.tgz#605f8a2c17ab8da2af4456110f4d0a02b384e3d0"
+  integrity sha512-NaaHMboU9tKwrU3aim7LlzSDqKb+1TGaC+Lx3NOttSnuMHbPpaf+7LtJL4KlosbRWEwqb9t5wSYMVDrPTH2dNA==
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.9"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
+
 algoliasearch@^3.29.0:
   version "3.30.0"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.30.0.tgz#355585e49b672e5f71d45b9c2b371ecdff129cd1"
@@ -1681,7 +1702,7 @@ debug@*:
   dependencies:
     ms "^2.1.1"
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==

--- a/examples/storybook/package.json
+++ b/examples/storybook/package.json
@@ -13,6 +13,7 @@
     "@angular/forms": "7.0.2",
     "@angular/platform-browser": "7.0.2",
     "@angular/platform-browser-dynamic": "7.0.2",
+    "algoliasearch": "3.32.1",
     "angular-instantsearch": "3.0.0-beta.0",
     "core-js": "2.5.4",
     "instantsearch.js": "3.4.0",

--- a/examples/storybook/src/wrap-with-hits.ts
+++ b/examples/storybook/src/wrap-with-hits.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import algoliasearch from 'algoliasearch/lite';
 
 type Helper = {
   search: Function;
@@ -12,8 +13,10 @@ type WrapWithHitsParams = {
   methods?: {};
   searchFunction?: (helper: Helper) => void;
   searchClient?: {};
-  filters?: string;
   indexName?: string;
+  appId?: string;
+  apiKey?: string;
+  filters?: string;
   hits?: string;
   routing?: boolean | {};
 };
@@ -47,8 +50,9 @@ export function wrapWithHits({
   searchParameters = {},
   methods = {},
   searchFunction,
-  searchClient,
   indexName = 'instant_search',
+  appId = 'latency',
+  apiKey = '6be0576ff61c053d5f9a3225e2a90f76',
   filters = `<ais-refinement-list attribute="brand"></ais-refinement-list>`,
   hits = defaultHits,
   routing,
@@ -78,13 +82,9 @@ export function wrapWithHits({
   })
   class AppComponent {
     config = {
-      ...(!searchClient && {
-        appId: 'latency',
-        apiKey: '6be0576ff61c053d5f9a3225e2a90f76',
-      }),
-      searchFunction,
-      searchClient,
+      searchClient: algoliasearch(appId, apiKey),
       indexName,
+      searchFunction,
       searchParameters: {
         hitsPerPage: 3,
         ...searchParameters,

--- a/examples/storybook/yarn.lock
+++ b/examples/storybook/yarn.lock
@@ -1099,7 +1099,7 @@
     semver "5.5.1"
     semver-intersect "1.4.0"
 
-"@storybook/addon-actions@^5.0.10":
+"@storybook/addon-actions@~5.0.10":
   version "5.0.10"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-5.0.10.tgz#7791ee26c41c63f6d2f36ec0b41108ba9b138171"
   integrity sha512-zPwGMsS11uoKu/gBkBdcdXMtAle2u04O7B1rWFoHFtbQRX+ZDgtkjtSRldpn9t6MYEqJmZ4s3TUxbwv6hKeBOQ==
@@ -1838,6 +1838,27 @@ algoliasearch-helper@^2.26.0, algoliasearch-helper@^2.26.1:
     lodash "^4.17.5"
     qs "^6.5.1"
     util "^0.10.3"
+
+algoliasearch@3.32.1:
+  version "3.32.1"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.32.1.tgz#605f8a2c17ab8da2af4456110f4d0a02b384e3d0"
+  integrity sha512-NaaHMboU9tKwrU3aim7LlzSDqKb+1TGaC+Lx3NOttSnuMHbPpaf+7LtJL4KlosbRWEwqb9t5wSYMVDrPTH2dNA==
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.9"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
 
 algoliasearch@^3.29.0:
   version "3.30.0"
@@ -3654,7 +3675,7 @@ debug@*, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==

--- a/src/instantsearch/__tests__/instantsearch.spec.ts
+++ b/src/instantsearch/__tests__/instantsearch.spec.ts
@@ -2,6 +2,7 @@ import { NgAisInstantSearchModule } from '../instantsearch.module';
 import { Component, VERSION as AngularVersion } from '@angular/core';
 import { VERSION } from '../../version';
 import { TestBed } from '@angular/core/testing';
+
 jest.mock('instantsearch.js/es', () => ({
   default: () => {
     return {
@@ -17,16 +18,18 @@ jest.mock('../../../src/base-widget');
 
 describe('InstantSearch', () => {
   it('should add user agent when the client is provided to the config', () => {
-    const addAlgoliaAgent = jest.fn();
+    const searchClient = {
+      addAlgoliaAgent: jest.fn(),
+      search: jest.fn(),
+    };
+
     @Component({
       template: `<ais-instantsearch [config]="config"> </ais-instantsearch>`,
     })
     class TestContainer {
       public config = {
-        appId: 'theAppId',
-        apiKey: 'theApiKey',
         indexName: 'theIndexName',
-        searchClient: { addAlgoliaAgent },
+        searchClient,
       };
     }
 
@@ -40,25 +43,28 @@ describe('InstantSearch', () => {
     const fixture = TestBed.createComponent(TestContainer);
     fixture.detectChanges();
 
-    expect(addAlgoliaAgent).toHaveBeenCalledTimes(2);
-    expect(addAlgoliaAgent).toHaveBeenCalledWith(
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledTimes(2);
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
       `angular (${AngularVersion.full})`
     );
-    expect(addAlgoliaAgent).toHaveBeenCalledWith(
+    expect(searchClient.addAlgoliaAgent).toHaveBeenCalledWith(
       `angular-instantsearch (${VERSION})`
     );
   });
 
   it('should not add a user agent when addAlgoliaAgent is not provided in the client', () => {
+    const searchClient = {
+      addAlgoliaAgent: jest.fn(),
+      search: jest.fn(),
+    };
+
     @Component({
       template: `<ais-instantsearch [config]="config"> </ais-instantsearch>`,
     })
     class TestContainer {
       public config = {
-        appId: 'theAppId',
-        apiKey: 'theApiKey',
         indexName: 'theIndexName',
-        searchClient: {},
+        searchClient,
       };
     }
 

--- a/src/instantsearch/instantsearch.ts
+++ b/src/instantsearch/instantsearch.ts
@@ -155,11 +155,11 @@ export type SearchClient = {
 };
 
 export type InstantSearchConfig = {
+  searchClient: SearchClient;
   indexName: string;
 
   numberLocale?: string;
   searchFunction?: (helper: AlgoliaSearchHelper) => void;
-  searchClient: SearchClient;
   searchParameters?: SearchParameters | void;
   urlSync?:
     | boolean

--- a/src/instantsearch/instantsearch.ts
+++ b/src/instantsearch/instantsearch.ts
@@ -155,18 +155,11 @@ export type SearchClient = {
 };
 
 export type InstantSearchConfig = {
-  appId?: string;
-  apiKey?: string;
   indexName: string;
 
   numberLocale?: string;
   searchFunction?: (helper: AlgoliaSearchHelper) => void;
-  createAlgoliaClient?: (
-    algoliasearch: Function,
-    appId: string,
-    apiKey: string
-  ) => object;
-  searchClient?: SearchClient;
+  searchClient: SearchClient;
   searchParameters?: SearchParameters | void;
   urlSync?:
     | boolean
@@ -261,19 +254,11 @@ export class NgAisInstantSearch implements AfterViewInit, OnInit, OnDestroy {
       if (typeof config.routing !== 'undefined') delete config.routing;
     }
 
-    if (!config.searchClient && !config.createAlgoliaClient) {
-      const client = algoliasearch(config.appId, config.apiKey);
-      config.searchClient = client;
-      config.appId = undefined;
-      config.apiKey = undefined;
-    }
-
-    // custom algolia client agent
     if (typeof config.searchClient.addAlgoliaAgent === 'function') {
-      // add user agents
       config.searchClient.addAlgoliaAgent(`angular (${AngularVersion.full})`);
       config.searchClient.addAlgoliaAgent(`angular-instantsearch (${VERSION})`);
     }
+
     this.instantSearchInstance = instantsearch(config);
     this.instantSearchInstance.on('render', this.onRender);
   }


### PR DESCRIPTION
## Description

This enforces the `searchClient` option for Angular InstantSearch v3 and drops support for `appId` and `apiKey`. This change is necessary to be aligned with other InstantSearch flavors. It also removes `createAlgoliaClient` which is replaced by `searchClient`.

## Notes

- All examples were updated (there's some noise because some files were not formatted).
- The storybook was updated to use `searchClient`. It can still be overridden internally in the stories if you pass `appId` and `apiKey`.
- I didn't update `createSSRSearchClient` in this PR.

## Preview

[See examples →](https://deploy-preview-496--angular-instantsearch.netlify.com/examples.html)