### PR TITLE
chore(tests): add support for passing methods in createRenderer

### DIFF
--- a/helpers/test-renderer.ts
+++ b/helpers/test-renderer.ts
@@ -13,12 +13,14 @@ export function createRenderer({
   defaultState,
   additionalImports,
   additionalDeclarations,
+  methods = {},
 }: {
   template: string;
   TestedWidget: any;
   additionalImports?: any[];
   additionalDeclarations?: any[];
   defaultState?: {};
+  methods?: {};
 }) {
   return function(state?: {}, firstRender = false) {
     return render(
@@ -28,6 +30,7 @@ export function createRenderer({
         additionalImports,
         additionalDeclarations,
         state: state ? { ...(defaultState || {}), ...state } : undefined,
+        methods,
       },
       firstRender
     );
@@ -41,12 +44,14 @@ function render(
     additionalImports,
     additionalDeclarations,
     state,
+    methods,
   }: {
     template: string;
     TestedWidget: any;
     additionalImports?: any[];
     additionalDeclarations?: any[];
     state?: {};
+    methods?: {};
   },
   firstRender = false
 ) {
@@ -59,6 +64,11 @@ function render(
   })
   class TestContainer {
     @ViewChild(TestedWidget) testedWidget;
+    constructor() {
+      Object.keys(methods).forEach(methodName => {
+        this[methodName] = methods[methodName];
+      });
+    }
   }
 
   TestBed.configureCompiler({


### PR DESCRIPTION
⚠️  This PR is stacked on #498 for convenience.

This serves usecases for testing parameters of type Function.

This code snippets demonstrates it:

```ts
const transformItems = jest.fn()
const render = createRenderer({
  defaultState,
  template: '<ais-breadcrumb></ais-breadcrumb>',
  TestedWidget: NgAisBreadcrumb,
  methods: {
    transformItems,
  }
});

const fixture = render();

expect(fixture.componentInstance.testedWidget.transformItems).toEqual(transformItems)
```

This imitates what we can find in the [`wrapWithHits` function from the storybook example](https://github.com/algolia/angular-instantsearch/blob/develop/examples/storybook/src/wrap-with-hits.ts#L12).

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->
