### PR TITLE
chore: disable canonical link

### DIFF
--- a/community-website/src/community-project-boilerplate-docgen/layouts/common/meta.pug
+++ b/community-website/src/community-project-boilerplate-docgen/layouts/common/meta.pug
@@ -31,5 +31,5 @@ meta(content=project, property='og:site_name')
 title #{project} | #{short_desc}
 link(rel="stylesheet", href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css")
 link(rel='stylesheet', href="stylesheets/index.css")
-if canonical
-  link(rel='canonical', href=canonical)
+
+meta(name="robots", content="noindex, nofollow")


### PR DESCRIPTION
**Summary**

We introduce [the canonical URLs](https://github.com/algolia/angular-instantsearch/pull/467/files) to keep backlinks to the algolia.com/doc. But it's not enough to make the Community website disappear from the search results. We have to hide them from the search results otherwise it's confusing for users.

https://github.com/algolia/instantsearch.js/pull/3748