### PR TITLE
fix(InfiniteHits): improve typing

### DIFF
--- a/src/infinite-hits/infinite-hits.ts
+++ b/src/infinite-hits/infinite-hits.ts
@@ -12,6 +12,22 @@ import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { noop } from '../utils';
 
+export type InfiniteHitsState = {
+  hits: InfiniteHitsItem[];
+  results: {};
+  isFirstPage: boolean;
+  isLastPage: boolean;
+  showMore: Function;
+  showPrevious: Function;
+};
+
+export type InfiniteHitsItem = {
+  [attribute: string]: any;
+  objectID: string;
+  __position: number;
+  __queryID?: string;
+};
+
 @Component({
   selector: 'ais-infinite-hits',
   template: `
@@ -58,17 +74,13 @@ export class NgAisInfiniteHits extends BaseWidget {
   @Input() public showPrevious: boolean = false;
   @Input() public showPreviousLabel: string = 'Show previous results';
   @Input() public showMoreLabel: string = 'Show more results';
-  @Input() public transformItems?: Function;
+  @Input()
+  public transformItems?: <U extends InfiniteHitsItem>(
+    items: InfiniteHitsItem[]
+  ) => U[];
 
   // inner widget state returned from connector
-  public state: {
-    hits: {}[];
-    isFirstPage: boolean;
-    isLastPage: boolean;
-    showMore: Function;
-    showPrevious: Function;
-    results: {};
-  } = {
+  public state: InfiniteHitsState = {
     hits: [],
     isFirstPage: false,
     isLastPage: false,

--- a/src/infinite-hits/infinite-hits.ts
+++ b/src/infinite-hits/infinite-hits.ts
@@ -14,7 +14,7 @@ import { noop } from '../utils';
 
 export type InfiniteHitsState = {
   hits: InfiniteHitsItem[];
-  results: {};
+  results: any;
   isFirstPage: boolean;
   isLastPage: boolean;
   showMore: Function;

--- a/src/infinite-hits/infinite-hits.ts
+++ b/src/infinite-hits/infinite-hits.ts
@@ -9,23 +9,16 @@ import {
 
 import { connectInfiniteHitsWithInsights } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
-import { NgAisInstantSearch } from '../instantsearch/instantsearch';
+import { NgAisInstantSearch, Hit } from '../instantsearch/instantsearch';
 import { noop } from '../utils';
 
 export type InfiniteHitsState = {
-  hits: InfiniteHitsItem[];
+  hits: Hit[];
   results: any;
   isFirstPage: boolean;
   isLastPage: boolean;
   showMore: Function;
   showPrevious: Function;
-};
-
-export type InfiniteHitsItem = {
-  [attribute: string]: any;
-  objectID: string;
-  __position: number;
-  __queryID?: string;
 };
 
 @Component({
@@ -74,10 +67,7 @@ export class NgAisInfiniteHits extends BaseWidget {
   @Input() public showPrevious: boolean = false;
   @Input() public showPreviousLabel: string = 'Show previous results';
   @Input() public showMoreLabel: string = 'Show more results';
-  @Input()
-  public transformItems?: <U extends InfiniteHitsItem>(
-    items: InfiniteHitsItem[]
-  ) => U[];
+  @Input() public transformItems?: <U extends Hit>(items: Hit[]) => U[];
 
   // inner widget state returned from connector
   public state: InfiniteHitsState = {


### PR DESCRIPTION
**Summary**

Introduced `InfiniteHitsState` and `InfiniteHitsItem`.
I could have copy pasted some of the types we have in InstantSearch V3 but they are IO believe a little complex and will certainly be subject to changes.

I'm afraid if we systematically copy paste the types we have currently in IS V3 we'll just end up maintaining them in two different places or with a lot of inconsistencies.

Ideally IS V3 would allow importing the types and use them here directly. In the mean time, the idea is to keep Angular IS types very simple so they'll be easier to migrate to IS's complex types.

**Result**
N/A