### PR TITLE
style(HierarchicalMenu): move test render method inside tests

### DIFF
--- a/src/hierarchical-menu/__tests__/hierarchical-menu.spec.ts
+++ b/src/hierarchical-menu/__tests__/hierarchical-menu.spec.ts
@@ -25,25 +25,36 @@ const defaultState = {
   createURL: jest.fn(),
 };
 
-const render = createRenderer({
-  defaultState,
-  template: '<ais-hierarchical-menu></ais-hierarchical-menu>',
-  TestedWidget: NgAisHierarchicalMenu,
-  additionalDeclarations: [NgAisHierarchicalMenuItem],
-});
-
 describe('HierarchicalMenu', () => {
   it('renders markup without state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hierarchical-menu></ais-hierarchical-menu>',
+      TestedWidget: NgAisHierarchicalMenu,
+      additionalDeclarations: [NgAisHierarchicalMenuItem],
+    });
     const fixture = render();
     expect(fixture).toMatchSnapshot();
   });
 
   it('renders markup with state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hierarchical-menu></ais-hierarchical-menu>',
+      TestedWidget: NgAisHierarchicalMenu,
+      additionalDeclarations: [NgAisHierarchicalMenuItem],
+    });
     const fixture = render({});
     expect(fixture).toMatchSnapshot();
   });
 
   it('should call refine() on item click', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hierarchical-menu></ais-hierarchical-menu>',
+      TestedWidget: NgAisHierarchicalMenu,
+      additionalDeclarations: [NgAisHierarchicalMenuItem],
+    });
     const refine = jest.fn();
     const fixture = render({ refine });
 
@@ -73,6 +84,12 @@ describe('HierarchicalMenu', () => {
   });
 
   it('should be hidden with `autoHideContainer`', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hierarchical-menu></ais-hierarchical-menu>',
+      TestedWidget: NgAisHierarchicalMenu,
+      additionalDeclarations: [NgAisHierarchicalMenuItem],
+    });
     const fixture = render({ items: [] });
     fixture.componentInstance.testedWidget.autoHideContainer = true;
     fixture.detectChanges();

--- a/src/hierarchical-menu/__tests__/hierarchical-menu.spec.ts
+++ b/src/hierarchical-menu/__tests__/hierarchical-menu.spec.ts
@@ -68,6 +68,12 @@ describe('HierarchicalMenu', () => {
   });
 
   it('should apply `transformItems` if specified', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-hierarchical-menu></ais-hierarchical-menu>',
+      TestedWidget: NgAisHierarchicalMenu,
+      additionalDeclarations: [NgAisHierarchicalMenuItem],
+    });
     const fixture = render({});
 
     const mapItems = items =>


### PR DESCRIPTION
**Summary**

This helps changing the template from one test to the other.
It prepares for tests I'll write checking how props declared on the
widget are passed to the connector as instance props.

I isolated them in a separate PR.

**Results**

Nothing should change