### PR TITLE
docs(HierarchicalMenu): add example showcasing transformItems

### DIFF
--- a/examples/storybook/src/stories/HierarchicalMenu.stories.ts
+++ b/examples/storybook/src/stories/HierarchicalMenu.stories.ts
@@ -53,4 +53,29 @@ storiesOf('HierarchicalMenu', module)
         },
       },
     }),
-  }));
+  }))
+  .add('with transformItems', () => {
+    const transformItems = items =>
+      items.map(item => ({
+        ...item,
+        label: `${item.label} (transformed)`,
+        data: item.data ? transformItems(item.data) : null,
+      }));
+
+    return {
+      component: wrapWithHits({
+        template: `
+        <ais-hierarchical-menu
+          [attributes]="[
+            'hierarchicalCategories.lvl0',
+            'hierarchicalCategories.lvl1',
+            'hierarchicalCategories.lvl2'
+          ]"
+          [transformItems]="transformItems"
+        >
+        </ais-hierarchical-menu>
+        `,
+        methods: { transformItems },
+      }),
+    };
+  });


### PR DESCRIPTION
**Summary**

This adds a missing example showcasing transformItems usage in HierarchicalMenu.
I noticed this was missing when I migrated the widget to use transformItems provided by the connector.


**Result**

https://deploy-preview-559--angular-instantsearch.netlify.com/examples/storybook/?path=/story/hierarchicalmenu--with-transformitems
