### PR TITLE
fix(NumericMenu): use connector transformItems 

### DIFF
--- a/examples/storybook/src/stories/NumericMenu.stories.ts
+++ b/examples/storybook/src/stories/NumericMenu.stories.ts
@@ -22,4 +22,31 @@ storiesOf('NumericMenu', module)
       </ais-panel>
     `,
     }),
-  }));
+  }))
+  .add('with transformItems', () => {
+    const transformItems = items => {
+      return items.map(item => ({
+        ...item,
+        label: `${item.label} (transformed)`,
+      }));
+    };
+    return {
+      component: wrapWithHits({
+        template: `
+        <ais-numeric-menu
+          attribute="price"
+          [items]="[
+            { label: 'All' },
+            { end: 4, label: 'less than 4' },
+            { start: 4, end: 4, label: '4' },
+            { start: 5, end: 10, label: 'between 5 and 10' },
+            { start: 10, label: 'more than 10' }
+          ]"
+          [transformItems]="transformItems"
+        >
+        </ais-numeric-menu>
+        `,
+        methods: { transformItems },
+      }),
+    };
+  });

--- a/src/numeric-menu/__tests__/numeric-menu.spec.ts
+++ b/src/numeric-menu/__tests__/numeric-menu.spec.ts
@@ -1,3 +1,4 @@
+import { connectNumericMenu } from 'instantsearch.js/es/connectors';
 import { createRenderer } from '../../../helpers/test-renderer';
 import { NgAisNumericMenu } from '../numeric-menu';
 
@@ -10,24 +11,33 @@ const defaultState = {
   refine: jest.fn(),
 };
 
-const render = createRenderer({
-  defaultState,
-  template: '<ais-numeric-menu></ais-numeric-menu>',
-  TestedWidget: NgAisNumericMenu,
-});
-
 describe('NumericRefinementList', () => {
   it('renders markup without state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-numeric-menu></ais-numeric-menu>',
+      TestedWidget: NgAisNumericMenu,
+    });
     const fixture = render();
     expect(fixture).toMatchSnapshot();
   });
 
   it('renders markup with state', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-numeric-menu></ais-numeric-menu>',
+      TestedWidget: NgAisNumericMenu,
+    });
     const fixture = render({});
     expect(fixture).toMatchSnapshot();
   });
 
   it('should refine() when label click', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-numeric-menu></ais-numeric-menu>',
+      TestedWidget: NgAisNumericMenu,
+    });
     const refine = jest.fn();
     const fixture = render({ refine });
 
@@ -41,6 +51,11 @@ describe('NumericRefinementList', () => {
   });
 
   it('should not refine() on 2nd label click', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-numeric-menu></ais-numeric-menu>',
+      TestedWidget: NgAisNumericMenu,
+    });
     const refine = jest.fn();
     const fixture = render({ refine });
 
@@ -69,6 +84,11 @@ describe('NumericRefinementList', () => {
   });
 
   it('should check the input of item.isRefined', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-numeric-menu></ais-numeric-menu>',
+      TestedWidget: NgAisNumericMenu,
+    });
     const fixture = render({});
     const [
       firstInput,
@@ -80,10 +100,48 @@ describe('NumericRefinementList', () => {
   });
 
   it('should be hidden with autoHideContainer', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-numeric-menu></ais-numeric-menu>',
+      TestedWidget: NgAisNumericMenu,
+    });
     const fixture = render({ items: [] });
     fixture.componentInstance.testedWidget.autoHideContainer = true;
     fixture.detectChanges();
 
     expect(fixture).toMatchSnapshot();
+  });
+
+  it('should create widget with connectNumericMenu and pass instance options', () => {
+    const createWidget = jest.spyOn(NgAisNumericMenu.prototype, 'createWidget');
+
+    const items = [
+      { label: 'All' },
+      { label: 'Less than 500$', end: 500 },
+      { label: 'Between 500$ - 1000$', start: 500, end: 1000 },
+      { label: 'More than 1000$', start: 1000 },
+    ];
+    const transformItems = jest.fn(x => x);
+    const render = createRenderer({
+      defaultState,
+      template: `
+      <ais-numeric-menu 
+        attribute="price" 
+        [items]="items" 
+        [transformItems]="transformItems"></ais-numeric-menu>`,
+      TestedWidget: NgAisNumericMenu,
+      methods: { items, transformItems },
+    });
+
+    render({});
+
+    expect(createWidget).toHaveBeenCalledTimes(1);
+    expect(createWidget).toHaveBeenCalledWith(connectNumericMenu, {
+      attribute: 'price',
+      items,
+      transformItems,
+    });
+
+    createWidget.mockRestore();
   });
 });

--- a/src/numeric-menu/numeric-menu.ts
+++ b/src/numeric-menu/numeric-menu.ts
@@ -48,7 +48,10 @@ export type NumericMenuState = {
 export class NgAisNumericMenu extends BaseWidget {
   @Input() public attribute: string;
   @Input() public items: { label: string; start?: number; end?: number }[];
-  // TODO: add prop transformItem
+  @Input()
+  public transformItems?: <U extends NumericMenuItem>(
+    items: NumericMenuItem[]
+  ) => U[];
 
   public state: NumericMenuState = {
     items: [],
@@ -71,6 +74,7 @@ export class NgAisNumericMenu extends BaseWidget {
     this.createWidget(connectNumericMenu, {
       attribute: this.attribute,
       items: this.items,
+      transformItems: this.transformItems,
     });
     super.ngOnInit();
   }


### PR DESCRIPTION
**Summary**

This migrates NumericMenu to use the transformItems provided by the connector. It also removes the test related and replaces it with one that checks all instance options are correctly applied to the connector.


**Result**

https://deploy-preview-560--angular-instantsearch.netlify.com/examples/storybook/?path=/story/numericmenu--with-transformitems

ref https://github.com/algolia/angular-instantsearch/issues/372