### PR TITLE
fix(ClearRefinements): use connector transformItems

### DIFF
--- a/examples/storybook/src/stories/ClearRefinements.stories.ts
+++ b/examples/storybook/src/stories/ClearRefinements.stories.ts
@@ -27,4 +27,24 @@ storiesOf('ClearRefinements', module)
         disjunctiveFacets: ['brand'],
       },
     }),
-  }));
+  }))
+  .add('with transformItems', () => {
+    const transformItems = items => items.filter(item => item !== 'brand');
+
+    return {
+      component: wrapWithHits({
+        template:
+          "<ais-clear-refinements resetLabel='Clear all but `brand` refinement' [transformItems]='transformItems'></ais-clear-refinements>",
+        filters: ` 
+         <ais-panel header="Brand">
+            <ais-refinement-list attribute="brand"> </ais-refinement-list> 
+         </ais-panel>
+         
+         <ais-panel header="Category">
+            <ais-hierarchical-menu [attributes]="[ 'hierarchicalCategories.lvl0', 'hierarchicalCategories.lvl1', 'hierarchicalCategories.lvl2' ]"> </ais-hierarchical-menu> 
+         </ais-panel>
+        `,
+        methods: { transformItems },
+      }),
+    };
+  });

--- a/src/clear-refinements/__tests__/clear-refinements.spec.ts
+++ b/src/clear-refinements/__tests__/clear-refinements.spec.ts
@@ -1,31 +1,46 @@
+import { connectClearRefinements } from 'instantsearch.js/es/connectors';
 import { createRenderer } from '../../../helpers/test-renderer';
 import { NgAisClearRefinements } from '../clear-refinements';
 
-const render = createRenderer({
-  defaultState: {},
-  template: '<ais-clear-refinements></ais-clear-refinements>',
-  TestedWidget: NgAisClearRefinements,
-});
-
 describe('ClearRefinements', () => {
   it('renders markup without state', () => {
+    const render = createRenderer({
+      defaultState: {},
+      template: '<ais-clear-refinements></ais-clear-refinements>',
+      TestedWidget: NgAisClearRefinements,
+    });
     const fixture = render();
     expect(fixture).toMatchSnapshot();
   });
 
   it('should render disabled button when no refinements', () => {
+    const render = createRenderer({
+      defaultState: {},
+      template: '<ais-clear-refinements></ais-clear-refinements>',
+      TestedWidget: NgAisClearRefinements,
+    });
     const fixture = render();
     const btn = fixture.debugElement.nativeElement.querySelector('button');
     expect(btn.disabled).toBeTruthy();
   });
 
   it('should render enabled button when refinements', () => {
+    const render = createRenderer({
+      defaultState: {},
+      template: '<ais-clear-refinements></ais-clear-refinements>',
+      TestedWidget: NgAisClearRefinements,
+    });
     const fixture = render({ hasRefinements: true, refine: jest.fn() });
     const btn = fixture.debugElement.nativeElement.querySelector('button');
     expect(btn.disabled).toBeFalsy();
   });
 
   it('should call refine() when clicked on button', () => {
+    const render = createRenderer({
+      defaultState: {},
+      template: '<ais-clear-refinements></ais-clear-refinements>',
+      TestedWidget: NgAisClearRefinements,
+    });
     const spy = jest.fn();
     const fixture = render({ hasRefinements: true, refine: spy });
 
@@ -36,8 +51,49 @@ describe('ClearRefinements', () => {
   });
 
   it('should be hidden with `autoHideContainer`', () => {
+    const render = createRenderer({
+      defaultState: {},
+      template: '<ais-clear-refinements></ais-clear-refinements>',
+      TestedWidget: NgAisClearRefinements,
+    });
     const fixture = render({ hasRefinements: false });
     fixture.componentInstance.testedWidget.autoHideContainer = true;
     fixture.detectChanges();
+  });
+
+  it('should create widget with connectClearRefinements and pass instance options', () => {
+    const createWidget = jest.spyOn(
+      NgAisClearRefinements.prototype,
+      'createWidget'
+    );
+    const includedAttributes = ['query'];
+    const excludedAttributes = ['brand'];
+    const transformItems = jest.fn(x => x);
+
+    const render = createRenderer({
+      defaultState: {},
+      template: `<ais-clear-refinements 
+        [includedAttributes]="includedAttributes" 
+        [excludedAttributes]="excludedAttributes"
+        [transformItems]="transformItems">
+       </ais-clear-refinements>`,
+      TestedWidget: NgAisClearRefinements,
+      methods: {
+        includedAttributes,
+        excludedAttributes,
+        transformItems,
+      },
+    });
+
+    render();
+
+    expect(createWidget).toHaveBeenCalledTimes(1);
+    expect(createWidget).toHaveBeenCalledWith(connectClearRefinements, {
+      includedAttributes,
+      excludedAttributes,
+      transformItems,
+    });
+
+    createWidget.mockRestore();
   });
 });

--- a/src/clear-refinements/clear-refinements.ts
+++ b/src/clear-refinements/clear-refinements.ts
@@ -4,6 +4,12 @@ import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { noop } from '../utils';
 
+type ClearRefinementsState = {
+  hasRefinements: boolean;
+  refine: () => void;
+  createURL: () => string;
+};
+
 @Component({
   selector: 'ais-clear-refinements',
   template: `
@@ -28,15 +34,15 @@ export class NgAisClearRefinements extends BaseWidget {
   // instance options
   @Input() public includedAttributes: string[];
   @Input() public excludedAttributes: string[];
-  // TODO: add transformItems
+  @Input() public transformItems?: <U extends string>(items: string[]) => U[];
 
-  public state = {
+  public state: ClearRefinementsState = {
     hasRefinements: false,
     refine: noop,
-    // add createURL
+    createURL: () => '#',
   };
 
-  get isHidden() {
+  get isHidden(): boolean {
     return !this.state.hasRefinements && this.autoHideContainer;
   }
 
@@ -51,6 +57,7 @@ export class NgAisClearRefinements extends BaseWidget {
     this.createWidget(connectClearRefinements, {
       includedAttributes: this.includedAttributes,
       excludedAttributes: this.excludedAttributes,
+      transformItems: this.transformItems,
     });
 
     super.ngOnInit();

--- a/src/clear-refinements/clear-refinements.ts
+++ b/src/clear-refinements/clear-refinements.ts
@@ -34,7 +34,7 @@ export class NgAisClearRefinements extends BaseWidget {
   // instance options
   @Input() public includedAttributes: string[];
   @Input() public excludedAttributes: string[];
-  @Input() public transformItems?: <U extends string>(items: string[]) => U[];
+  @Input() public transformItems?: (items: string[]) => string[];
 
   public state: ClearRefinementsState = {
     hasRefinements: false,


### PR DESCRIPTION
**Summary**

This migrates ClearRefinements to use the transformItems provided by the connector.
- improves the typing
- changes `createURL` default to `() => '#'`
- adds a storybook example for transformItems

⚠️ if you think there are too many changes, I can split it up.

ref https://github.com/algolia/angular-instantsearch/issues/372