### PR TITLE
 feat(Hits): expose escapeHTML instance option 

### DIFF
--- a/src/hits/__tests__/hits.spec.ts
+++ b/src/hits/__tests__/hits.spec.ts
@@ -42,7 +42,8 @@ describe('Hits', () => {
     const transformItems = jest.fn(x => x);
     const render = createRenderer({
       defaultState,
-      template: '<ais-hits [transformItems]="transformItems"></ais-hits>',
+      template:
+        '<ais-hits [escapeHTML]="false" [transformItems]="transformItems"></ais-hits>',
       TestedWidget: NgAisHits,
       additionalDeclarations: [NgAisHighlight],
       methods: { transformItems },
@@ -51,6 +52,7 @@ describe('Hits', () => {
     render({});
 
     expect(createWidget).toHaveBeenCalledWith(connectHitsWithInsights, {
+      escapeHTML: false,
       transformItems,
     });
     createWidget.mockRestore();

--- a/src/hits/hits.ts
+++ b/src/hits/hits.ts
@@ -40,6 +40,7 @@ export type HitsState = {
 export class NgAisHits extends BaseWidget {
   @ContentChild(TemplateRef) public template?: TemplateRef<any>;
 
+  @Input() public escapeHTML?: boolean;
   @Input() public transformItems?: <U extends Hit>(items: Hit[]) => U[];
 
   public state: HitsState = {
@@ -56,6 +57,7 @@ export class NgAisHits extends BaseWidget {
 
   ngOnInit() {
     this.createWidget(connectHitsWithInsights, {
+      escapeHTML: this.escapeHTML,
       transformItems: this.transformItems,
     });
     super.ngOnInit();


### PR DESCRIPTION
⚠️ This PR is stacked on top of https://github.com/algolia/angular-instantsearch/pull/551 and follows up on https://github.com/algolia/angular-instantsearch/pull/551#discussion_r284146310

**Summary**


- feat(Hits): expose escapeHTML instance option This exposed `escapeHTML` on the ais-hits.

https://www.algolia.com/doc/api-reference/widgets/hits/js/#widget-param-escapehtml

**Usage**
```ts
<ais-hits [escapeHTML]="false">
  <ng-template let-hits="hits">
    <div *ngFor="let hit of hits">
      <span [innerHTML]="hit.name"></span>
    </div>
  </ng-template>
<ais-hits>
```
- docs(Hits): add story for escapeHTML in hits

**Result**

// to be added
