### PR TITLE
chore(storybook): pass styles prop to wrapped component

### DIFF
--- a/examples/storybook/src/wrap-with-hits.ts
+++ b/examples/storybook/src/wrap-with-hits.ts
@@ -8,7 +8,7 @@ type Helper = {
 
 type WrapWithHitsParams = {
   template: string;
-  styles?: string;
+  styles?: string[];
   searchParameters?: {};
   methods?: {};
   searchFunction?: (helper: Helper) => void;
@@ -48,7 +48,7 @@ const defaultHits = `
 
 export function wrapWithHits({
   template,
-  styles = '',
+  styles = [],
   searchParameters = {},
   methods = {},
   searchFunction,
@@ -62,6 +62,7 @@ export function wrapWithHits({
 }: WrapWithHitsParams) {
   @Component({
     selector: 'ais-app',
+    styles,
     template: `
       <ais-instantsearch [config]="config">
         <div class="ais-container ais-container-preview">


### PR DESCRIPTION
**Summary**

This PR passes `styles` prop to wrapped component.
This is to provide a way to add story-specific styles, not polluting the global style.
The type of `styles` has changed from `?: string` to `?: string[]`, but there were no use case at all.
So it's safe to change like this.