### PR TITLE
chore: remove duplicated builds on netlify

### DIFF
--- a/scripts/build-example.sh
+++ b/scripts/build-example.sh
@@ -2,8 +2,13 @@
 
 set -e # exit when error
 
-yarn
-yarn build
+if [ "$SKIP_PACKAGE_BUILD" == "true" ]; then
+  echo "Skipping package build..."
+else
+  echo "Building package first..."
+  yarn
+  yarn build
+fi
 
 (
   cd examples/$1

--- a/scripts/netlify.sh
+++ b/scripts/netlify.sh
@@ -2,6 +2,7 @@
 
 set -e # exit when error
 
+rm -rf ./netlify-dist
 mkdir -p ./netlify-dist/examples
 
 # build community website
@@ -9,11 +10,15 @@ mkdir -p ./netlify-dist/examples
 (cd community-website && ROOT_PATH=$ROOT_PATH yarn docs:build)
 mv ./community-website/docs/* ./netlify-dist/
 
+# build package
+yarn
+yarn build
+
 # build examples
-yarn examples:ecommerce:build
-yarn examples:router:build
-yarn examples:media:build
-yarn examples:storybook:build
+SKIP_PACKAGE_BUILD=true yarn examples:ecommerce:build
+SKIP_PACKAGE_BUILD=true yarn examples:router:build
+SKIP_PACKAGE_BUILD=true yarn examples:media:build
+SKIP_PACKAGE_BUILD=true yarn examples:storybook:build
 
 mv ./examples/e-commerce/dist ./netlify-dist/examples/e-commerce
 mv ./examples/angular-router/dist ./netlify-dist/examples/angular-router


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This removes duplicated builds on netlify.
It will build the package once in `netlify.sh` and each `build-example.sh` will skip it due to the new environment variable `SKIP_PACKAGE_BUILD`.


**Why?**
It's slow when deploying on netlify.
`netlify.sh` builds four examples, which executes `build.sh` four times.
Inside `build.sh`, it builds the package(`yarn && yarn build`).
It means `yarn && yarn build` is executed every time `build.sh` runs,
which means it's duplicated, unnecessary and slow.

Before starting to build four examples, we should just run `yarn && yarn build` once and
let `build.sh` skip it.

**Result**
On my local machine,

```
before this commit
real    2m11.944s
user    3m18.983s
sys     0m16.899s


after
real    1m36.704s
user    2m30.385s
sys     0m12.814s
```

I diffed the two sets of build output `dist-netlify/` (before/after commit) and they're the same.

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->