### PR TITLE
fix(pagination): set showLast as true by default

### DIFF
--- a/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
+++ b/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
@@ -97,6 +97,16 @@ exports[`Pagination renders does not uses pagesPadding when nbPages < pagesPaddi
             </a>
           </li>
           
+          <li
+            class="ais-Pagination-item ais-Pagination-item--lastPage"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ›› 
+            </a>
+          </li>
         </ul>
       </div>
     </ais-pagination>
@@ -151,6 +161,16 @@ exports[`Pagination renders markup without state 1`] = `
             </a>
           </li>
           
+          <li
+            class="ais-Pagination-item ais-Pagination-item--lastPage"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ›› 
+            </a>
+          </li>
         </ul>
       </div>
     </ais-pagination>
@@ -275,6 +295,16 @@ exports[`Pagination renders with pages in state 1`] = `
             </a>
           </li>
           
+          <li
+            class="ais-Pagination-item ais-Pagination-item--lastPage"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ›› 
+            </a>
+          </li>
         </ul>
       </div>
     </ais-pagination>

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -106,7 +106,7 @@ import { parseNumberInput, noop } from '../utils';
 export class NgAisPagination extends BaseWidget {
   // rendering options
   @Input() public showFirst: boolean = true;
-  @Input() public showLast: boolean = false;
+  @Input() public showLast: boolean = true;
   @Input() public showPrevious: boolean = true;
   @Input() public showNext: boolean = true;
   @Input() public padding: number | string = 3;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

According to [the spec](https://instantsearch-css.netlify.com/widgets/pagination/), the default value of `showLast` of `ais-pagination` is supposed to be `true`, which isn't at the moment. This PR fixes this.


**Result**
The default value of `showLast` of `ais-pagination` becomes `true`.