### PR TITLE
fix(toggle): update checkbox when clicking the checkbox itself

### DIFF
--- a/src/toggle/__tests__/__snapshots__/toggle.spec.ts.snap
+++ b/src/toggle/__tests__/__snapshots__/toggle.spec.ts.snap
@@ -9,33 +9,25 @@ exports[`Toggle should render with a label 1`] = `
       <div
         class="ais-ToggleRefinement"
       >
-        <ul
-          class="ais-ToggleRefinement-list"
+        <label
+          class="ais-ToggleRefinement-label"
         >
-          <li
-            class="ais-ToggleRefinement-item"
+          <input
+            class="ais-ToggleRefinement-checkbox"
+            type="checkbox"
+            value="foobar"
+          />
+          <span
+            class="ais-ToggleRefinement-labelText"
           >
-            <label
-              class="ais-ToggleRefinement-label"
-            >
-              <input
-                class="ais-ToggleRefinement-checkbox"
-                type="checkbox"
-                value="foobar"
-              />
-              <span
-                class="ais-ToggleRefinement-labelText"
-              >
-                 Foo Label 
-              </span>
-              <span
-                class="ais-ToggleRefinement-count"
-              >
-                666
-              </span>
-            </label>
-          </li>
-        </ul>
+             Foo Label 
+          </span>
+          <span
+            class="ais-ToggleRefinement-count"
+          >
+            666
+          </span>
+        </label>
       </div>
     </ais-toggle>
   </ais-instantsearch>
@@ -51,33 +43,25 @@ exports[`Toggle should render with state 1`] = `
       <div
         class="ais-ToggleRefinement"
       >
-        <ul
-          class="ais-ToggleRefinement-list"
+        <label
+          class="ais-ToggleRefinement-label"
         >
-          <li
-            class="ais-ToggleRefinement-item"
+          <input
+            class="ais-ToggleRefinement-checkbox"
+            type="checkbox"
+            value="foobar"
+          />
+          <span
+            class="ais-ToggleRefinement-labelText"
           >
-            <label
-              class="ais-ToggleRefinement-label"
-            >
-              <input
-                class="ais-ToggleRefinement-checkbox"
-                type="checkbox"
-                value="foobar"
-              />
-              <span
-                class="ais-ToggleRefinement-labelText"
-              >
-                 foobar 
-              </span>
-              <span
-                class="ais-ToggleRefinement-count"
-              >
-                666
-              </span>
-            </label>
-          </li>
-        </ul>
+             foobar 
+          </span>
+          <span
+            class="ais-ToggleRefinement-count"
+          >
+            666
+          </span>
+        </label>
       </div>
     </ais-toggle>
   </ais-instantsearch>
@@ -93,33 +77,25 @@ exports[`Toggle should render without state 1`] = `
       <div
         class="ais-ToggleRefinement"
       >
-        <ul
-          class="ais-ToggleRefinement-list"
+        <label
+          class="ais-ToggleRefinement-label"
         >
-          <li
-            class="ais-ToggleRefinement-item"
+          <input
+            class="ais-ToggleRefinement-checkbox"
+            type="checkbox"
+            value=""
+          />
+          <span
+            class="ais-ToggleRefinement-labelText"
           >
-            <label
-              class="ais-ToggleRefinement-label"
-            >
-              <input
-                class="ais-ToggleRefinement-checkbox"
-                type="checkbox"
-                value=""
-              />
-              <span
-                class="ais-ToggleRefinement-labelText"
-              >
-                  
-              </span>
-              <span
-                class="ais-ToggleRefinement-count"
-              >
-                
-              </span>
-            </label>
-          </li>
-        </ul>
+              
+          </span>
+          <span
+            class="ais-ToggleRefinement-count"
+          >
+            
+          </span>
+        </label>
       </div>
     </ais-toggle>
   </ais-instantsearch>

--- a/src/toggle/__tests__/toggle.spec.ts
+++ b/src/toggle/__tests__/toggle.spec.ts
@@ -39,7 +39,7 @@ describe('Toggle', () => {
     const refine = jest.fn();
     const fixture = render({ refine });
 
-    const toggle = fixture.debugElement.nativeElement.querySelector('li');
+    const toggle = fixture.debugElement.nativeElement.querySelector('label');
     toggle.click();
 
     expect(refine).toHaveBeenCalled();

--- a/src/toggle/__tests__/toggle.spec.ts
+++ b/src/toggle/__tests__/toggle.spec.ts
@@ -42,7 +42,7 @@ describe('Toggle', () => {
     const toggle = fixture.debugElement.nativeElement.querySelector('label');
     toggle.click();
 
-    expect(refine).toHaveBeenCalled();
+    expect(refine).toHaveBeenCalledTimes(1);
     expect(refine).toHaveBeenCalledWith(defaultState.value);
   });
 });

--- a/src/toggle/toggle.ts
+++ b/src/toggle/toggle.ts
@@ -27,26 +27,21 @@ export type ToggleState = {
   selector: 'ais-toggle',
   template: `
     <div [class]="cx()">
-      <ul [class]="cx('list')">
-        <li
-          [class]="cx('item')"
-          (click)="handleClick($event)">
-          <label [class]="cx('label')">
-            <input
-              [class]="cx('checkbox')"
-              type="checkbox"
-              value="{{state.value.name}}"
-              [checked]="state.value.isRefined"
-            />
+      <label [class]="cx('label')">
+        <input
+          [class]="cx('checkbox')"
+          type="checkbox"
+          value="{{state.value.name}}"
+          [checked]="state.value.isRefined"
+          (change)="handleChange($event)"
+        />
 
-            <span [class]="cx('labelText')">
-              {{label || state.value.name}}
-            </span>
+        <span [class]="cx('labelText')">
+          {{label || state.value.name}}
+        </span>
 
-            <span [class]="cx('count')">{{state.value.count}}</span>
-          </label>
-        </li>
-      </ul>
+        <span [class]="cx('count')">{{state.value.count}}</span>
+      </label>
     </div>
   `,
 })
@@ -81,7 +76,7 @@ export class NgAisToggle extends BaseWidget {
     super.ngOnInit();
   }
 
-  public handleClick(event: MouseEvent) {
+  public handleChange(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
     this.state.refine(this.state.value);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

closes #615

This PR fixes a bug that clicking checkbox didn't update the checkbox itself.
It also updates the dom output to align with [the spec](https://instantsearch-css.netlify.com/widgets/toggle-refinement/). It didn't have unnecessary ul and li elements wrapping the label.