### PR TITLE
chore(highlight): update internal implementation

### DIFF
--- a/src/highlight/highlight.ts
+++ b/src/highlight/highlight.ts
@@ -1,6 +1,7 @@
 const get = require('lodash/get');
 import { Component, Input } from '@angular/core';
 import { bem } from '../utils';
+import { highlight } from 'instantsearch.js/es/helpers';
 
 @Component({
   selector: 'ais-highlight',
@@ -9,30 +10,17 @@ import { bem } from '../utils';
 export class NgAisHighlight {
   @Input() attribute: string;
   @Input() hit: { _highlightResult?: {}; label?: string; highlighted?: string };
-  @Input() tagName: string = 'em';
+  @Input() tagName: string = 'mark';
 
   cx = bem('Highlight');
 
   get content() {
-    if (this.attribute === 'highlighted') {
-      return this.hit.highlighted
-        ? this.replaceWithTagName(this.hit.highlighted)
-        : this.hit.label;
-    }
-
     if (this.hit.hasOwnProperty('_highlightResult')) {
-      const attributeHighlighted = get(
-        this.hit._highlightResult,
-        this.attribute
-      );
-
-      // check that the attributeHighlighted is a string
-      if (
-        attributeHighlighted !== undefined &&
-        typeof attributeHighlighted.value === 'string'
-      ) {
-        return this.replaceWithTagName(attributeHighlighted.value);
-      }
+      return highlight({
+        attribute: this.attribute,
+        highlightedTagName: this.tagName,
+        hit: this.hit,
+      });
     }
 
     const fallback = get(this.hit, this.attribute);
@@ -47,14 +35,5 @@ export class NgAisHighlight {
     }
 
     return fallback;
-  }
-
-  replaceWithTagName(value: string) {
-    return value
-      .replace(
-        new RegExp('<em>', 'g'),
-        `<${this.tagName} class="${this.cx('highlighted')}">`
-      )
-      .replace(new RegExp('</em>', 'g'), `</${this.tagName}>`);
   }
 }

--- a/src/refinement-list/refinement-list.ts
+++ b/src/refinement-list/refinement-list.ts
@@ -12,6 +12,7 @@ export type RefinementListItem = {
   label: string;
   count: number;
   isRefined: boolean;
+  highlighted: string;
 };
 
 export type RefinementListState = {
@@ -58,7 +59,7 @@ export type RefinementListState = {
               [checked]="item.isRefined"
             />
             <span [class]="cx('labelText')">
-              <ais-highlight attribute="highlighted" [hit]="item"></ais-highlight>
+              <ais-highlight attribute="item" [hit]="item"></ais-highlight>
             </span>
             <span [class]="cx('count')">{{item.count}}</span>
           </label>
@@ -151,4 +152,19 @@ export class NgAisRefinementList extends BaseWidget {
       this.state.refine(item.value);
     }
   }
+
+  public updateState = (state: RefinementListState): void => {
+    this.state = {
+      ...state,
+      items: state.items.map(item =>
+        Object.assign({}, item, {
+          _highlightResult: {
+            item: {
+              value: item.highlighted,
+            },
+          },
+        })
+      ),
+    };
+  };
 }


### PR DESCRIPTION
closes #625 

**Summary**

This PR updates the internal implementation of `ais-highlight`. And according to the change, the implementation of `ais-refinement-list` changes as well.

- Each item in `items` at `ais-refinement-list` doesn't include `_highlightResult`. So `ais-highlight` had to have a conditional statement to handle the usage of `ais-refinement-list` specially. This PR adds `_highlightResult` to each item in `items` at `ais-refinement-list`, so the conditional statement in `ais-highlight` is now removed.
- `ais-highlight` used to handle regexpr by itself, but now it leverage `highlight` helper function from InstantSearch.js.
- The default value of `tagName` in `ais-highlight` was `em` and now it's `mark` which is the correct spec.

- [ ] need to update test cases