### PR TITLE
chore(examples): add design for empty result at e-commerce demo

### DIFF
--- a/examples/e-commerce/angular.json
+++ b/examples/e-commerce/angular.json
@@ -24,7 +24,8 @@
               "src/app/clear-filters.css",
               "src/app/header-search-box.css",
               "src/app/range-slider.css",
-              "src/app/pagination.css"
+              "src/app/pagination.css",
+              "src/app/no-results.css"
             ],
             "scripts": []
           },

--- a/examples/e-commerce/src/app/app.component.html
+++ b/examples/e-commerce/src/app/app.component.html
@@ -2,7 +2,8 @@
   <ais-configure
     [searchParameters]="{
       attributesToSnippet: ['description:10'],
-      snippetEllipsisText: '…'
+      snippetEllipsisText: '…',
+      removeWordsIfNoResults: 'allOptional'
     }"
   >
   </ais-configure>
@@ -192,6 +193,8 @@
           </ol>
         </ng-template>
       </ais-hits>
+
+      <app-no-results></app-no-results>
 
       <footer class="container-footer">
         <ais-pagination

--- a/examples/e-commerce/src/app/app.module.ts
+++ b/examples/e-commerce/src/app/app.module.ts
@@ -6,9 +6,16 @@ import { AppComponent } from './app.component';
 import { RatingMenu } from './rating-menu/rating-menu.component';
 import { Snippet } from './snippet/snippet.component';
 import { ResetFiltersMobile } from './reset-filters-mobile/reset-filters-mobile.component';
+import { NoResults } from './no-results/no-results.component';
 
 @NgModule({
-  declarations: [AppComponent, RatingMenu, Snippet, ResetFiltersMobile],
+  declarations: [
+    AppComponent,
+    RatingMenu,
+    Snippet,
+    ResetFiltersMobile,
+    NoResults,
+  ],
   imports: [BrowserModule, NgAisModule.forRoot()],
   providers: [],
   bootstrap: [AppComponent],

--- a/examples/e-commerce/src/app/no-results.css
+++ b/examples/e-commerce/src/app/no-results.css
@@ -1,0 +1,5 @@
+.hits-empty-state .ais-ClearRefinements-button::before {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='11' height='11' viewBox='0 0 11 11' %3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M0 0h11v11H0z' /%3E%3Cpath fill='%23000' fill-rule='nonzero' d='M8.26 2.75a3.896 3.896 0 1 0 1.102 3.262l.007-.056a.49.49 0 0 1 .485-.456c.253 0 .451.206.437.457 0 0 .012-.109-.006.061a4.813 4.813 0 1 1-1.348-3.887v-.987a.458.458 0 1 1 .917.002v2.062a.459.459 0 0 1-.459.459H7.334a.458.458 0 1 1-.002-.917h.928z' /%3E%3C/g%3E%3C/svg%3E");
+  width: 11px;
+  height: 11px;
+}

--- a/examples/e-commerce/src/app/no-results/no-results.component.ts
+++ b/examples/e-commerce/src/app/no-results/no-results.component.ts
@@ -1,0 +1,122 @@
+import { Inject, Component, forwardRef } from '@angular/core';
+
+import { BaseWidget, NgAisInstantSearch } from 'angular-instantsearch';
+import { connectHits } from 'instantsearch.js/es/connectors';
+
+export type HitsState = {};
+
+@Component({
+  selector: 'app-no-results',
+  template: `
+    <div *ngIf="state && state.results && state.results.nbHits === 0">
+      <div class="hits-empty-state">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          xmlns:xlink="http://www.w3.org/1999/xlink"
+          width="138"
+          height="138"
+          class="hits-empty-state-image"
+        >
+          <defs>
+            <linearGradient id="c" x1="50%" x2="50%" y1="100%" y2="0%">
+              <stop offset="0%" stop-color="#F5F5FA" />
+              <stop offset="100%" stop-color="#FFF" />
+            </linearGradient>
+            <path
+              id="b"
+              d="M68.71 114.25a45.54 45.54 0 1 1 0-91.08 45.54 45.54 0 0 1 0 91.08z"
+            />
+            <filter
+              id="a"
+              width="140.6%"
+              height="140.6%"
+              x="-20.3%"
+              y="-15.9%"
+              filterUnits="objectBoundingBox"
+            >
+              <feOffset dy="4" in="SourceAlpha" result="shadowOffsetOuter1" />
+              <feGaussianBlur
+                in="shadowOffsetOuter1"
+                result="shadowBlurOuter1"
+                stdDeviation="5.5"
+              />
+              <feColorMatrix
+                in="shadowBlurOuter1"
+                result="shadowMatrixOuter1"
+                values="0 0 0 0 0.145098039 0 0 0 0 0.17254902 0 0 0 0 0.380392157 0 0 0 0.15 0"
+              />
+              <feOffset dy="2" in="SourceAlpha" result="shadowOffsetOuter2" />
+              <feGaussianBlur
+                in="shadowOffsetOuter2"
+                result="shadowBlurOuter2"
+                stdDeviation="1.5"
+              />
+              <feColorMatrix
+                in="shadowBlurOuter2"
+                result="shadowMatrixOuter2"
+                values="0 0 0 0 0.364705882 0 0 0 0 0.392156863 0 0 0 0 0.580392157 0 0 0 0.2 0"
+              />
+              <feMerge>
+                <feMergeNode in="shadowMatrixOuter1" />
+                <feMergeNode in="shadowMatrixOuter2" />
+              </feMerge>
+            </filter>
+          </defs>
+          <g fill="none" fill-rule="evenodd">
+            <circle
+              cx="68.85"
+              cy="68.85"
+              r="68.85"
+              fill="#5468FF"
+              opacity=".07"
+            />
+            <circle
+              cx="68.85"
+              cy="68.85"
+              r="52.95"
+              fill="#5468FF"
+              opacity=".08"
+            />
+            <use fill="#000" filter="url(#a)" xlink:href="#b" />
+            <use fill="url(#c)" xlink:href="#b" />
+            <path
+              d="M76.01 75.44c5-5 5.03-13.06.07-18.01a12.73 12.73 0 0 0-18 .07c-5 4.99-5.03 13.05-.07 18a12.73 12.73 0 0 0 18-.06zm2.5 2.5a16.28 16.28 0 0 1-23.02.09A16.29 16.29 0 0 1 55.57 55a16.28 16.28 0 0 1 23.03-.1 16.28 16.28 0 0 1-.08 23.04zm1.08-1.08l-2.15 2.16 8.6 8.6 2.16-2.15-8.6-8.6z"
+              fill="#5369FF"
+            />
+          </g>
+        </svg>
+
+        <p class="hits-empty-state-title">
+          Sorry, we can&apos;t find any matches to your query!
+        </p>
+        <p class="hits-empty-state-description">
+          {{
+            state.results.getRefinements().length > 0
+              ? 'Try to reset your applied filters.'
+              : 'Please try another query.'
+          }}
+        </p>
+
+        <ais-clear-refinements
+          resetLabel="Clear filters"
+        >
+        </ais-clear-refinements>
+      </div>
+    </div>
+  `,
+})
+export class NoResults extends BaseWidget {
+  public state: HitsState = {};
+
+  constructor(
+    @Inject(forwardRef(() => NgAisInstantSearch))
+    public instantSearchParent: any
+  ) {
+    super('NoResults');
+  }
+
+  ngOnInit() {
+    this.createWidget(connectHits);
+    super.ngOnInit();
+  }
+}

--- a/examples/e-commerce/src/app/no-results/no-results.component.ts
+++ b/examples/e-commerce/src/app/no-results/no-results.component.ts
@@ -3,7 +3,12 @@ import { Inject, Component, forwardRef } from '@angular/core';
 import { BaseWidget, NgAisInstantSearch } from 'angular-instantsearch';
 import { connectHits } from 'instantsearch.js/es/connectors';
 
-export type HitsState = {};
+export type NoResultsState = {
+  results?: {
+    nbHits: number;
+    getRefinements: () => any[];
+  };
+};
 
 @Component({
   selector: 'app-no-results',
@@ -106,7 +111,7 @@ export type HitsState = {};
   `,
 })
 export class NoResults extends BaseWidget {
-  public state: HitsState = {};
+  public state: NoResultsState = {};
 
   constructor(
     @Inject(forwardRef(() => NgAisInstantSearch))


### PR DESCRIPTION
This adds the empty state when no hits are returned by the engine. It doesn't change the SFFV no results design.

related to: https://github.com/algolia/instantsearch.js/pull/3894
based on: https://github.com/algolia/react-instantsearch/pull/2601

## Implementation

If no filter are applied, the empty message asks the user to change the query. If there are filters applied, the empty message shows a different message and offers the user to clear the filters.

I added `removeWordsIfNoResults` to `allOptional` so that results are returned most of the time.

## Preview

- [Preview with only query leading to empty results](https://deploy-preview-634--angular-instantsearch.netlify.com/examples/e-commerce/?query=hellll)
- [Preview with filters leading to empty results](https://deploy-preview-634--angular-instantsearch.netlify.com/examples/e-commerce/?query=ddddasdfasd&hierarchicalMenu%5BhierarchicalCategories.lvl0%5D%5B0%5D=Cameras%20%26%20Camcorders)
- [Default preview](https://deploy-preview-634--angular-instantsearch.netlify.com/examples/e-commerce/)

## Related

- [Desktop design](https://app.zeplin.io/project/5acc8becfc0c980068fc12cc/screen/5d133b0a7695220487ab06e7)
- [Mobile design](https://app.zeplin.io/project/5acc8becfc0c980068fc12cc/screen/5d133b6fc0b0e869459947ca)