### PR TITLE
chore(bem): allow subElements on root CSS class

### DIFF
--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -15,6 +15,7 @@ describe('Utils', () => {
 
     it('generates className for subElement', () => {
       expect(cx('input', 'min')).toBe('ais-testWidget-input--min');
+      expect(cx('', 'min')).toBe('ais-testWidget--min');
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,13 @@
 export function bem(widgetName: string) {
   const cx = function(element?: string, subElement?: string) {
+    let cssClass = `ais-${widgetName}`;
     if (element) {
-      const scoppedWidgetName = `ais-${widgetName}-${element}`;
-
-      // output `ais-Widget-Xyz--abc`
-      if (subElement) {
-        return `${scoppedWidgetName}--${subElement}`;
-      }
-
-      // output `ais-Widget-Xyz`
-      return scoppedWidgetName;
+      cssClass += `-${element}`;
     }
-
-    // output `ais-Widget`
-    return `ais-${widgetName}`;
+    if (subElement) {
+      cssClass += `--${subElement}`;
+    }
+    return cssClass;
   };
   return cx;
 }


### PR DESCRIPTION
**Summary**

This is needed for adding CSS classes such as `ais-Pagination--noRefinement`
(referenced here: https://instantsearch-css.netlify.com/widgets/pagination/)



**Result**
```js
// before
expect(cx('', 'noRefinement')).toBe('ais-Pagination');

// after
expect(cx('', 'noRefinement')).toBe('ais-Pagination--noRefinement');
```


