### PR TITLE
fix: add `ais-Pagination--noRefinement` CSS class on root when nbPages <= 1

### DIFF
--- a/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
+++ b/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`Pagination renders does not uses pagesPadding when nbPages < pagesPaddi
     <ais-pagination>
       <div
         class="ais-Pagination"
+        ng-reflect-ng-class="ais-Pagination"
       >
         <ul
           class="ais-Pagination-list"
@@ -122,6 +123,7 @@ exports[`Pagination renders markup without state 1`] = `
     <ais-pagination>
       <div
         class="ais-Pagination"
+        ng-reflect-ng-class="ais-Pagination"
       >
         <ul
           class="ais-Pagination-list"
@@ -186,6 +188,7 @@ exports[`Pagination renders with pages in state 1`] = `
     <ais-pagination>
       <div
         class="ais-Pagination"
+        ng-reflect-ng-class="ais-Pagination"
       >
         <ul
           class="ais-Pagination-list"

--- a/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
+++ b/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`Pagination renders does not uses pagesPadding when nbPages < pagesPaddi
     <ais-pagination>
       <div
         class="ais-Pagination"
-        ng-reflect-ng-class="ais-Pagination"
+        ng-reflect-ng-class="ais-Pagination,"
       >
         <ul
           class="ais-Pagination-list"
@@ -122,8 +122,8 @@ exports[`Pagination renders markup without state 1`] = `
   <ais-instantsearch>
     <ais-pagination>
       <div
-        class="ais-Pagination"
-        ng-reflect-ng-class="ais-Pagination"
+        class="ais-Pagination ais-Pagination--noRefinement"
+        ng-reflect-ng-class="ais-Pagination,ais-Pagination-"
       >
         <ul
           class="ais-Pagination-list"
@@ -188,7 +188,7 @@ exports[`Pagination renders with pages in state 1`] = `
     <ais-pagination>
       <div
         class="ais-Pagination"
-        ng-reflect-ng-class="ais-Pagination"
+        ng-reflect-ng-class="ais-Pagination,"
       >
         <ul
           class="ais-Pagination-list"

--- a/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
+++ b/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
@@ -314,3 +314,228 @@ exports[`Pagination renders with pages in state 1`] = `
   </ais-instantsearch>
 </ng-component>
 `;
+
+exports[`Pagination should add ais-Pagination--noRefinement CSS class on root when nbPages === 0 1`] = `
+<ng-component
+  testedWidget={[Function NgAisPagination]}
+>
+  <ais-instantsearch>
+    <ais-pagination>
+      <div
+        class="ais-Pagination ais-Pagination--noRefinement"
+        ng-reflect-ng-class="ais-Pagination,ais-Pagination-"
+      >
+        <ul
+          class="ais-Pagination-list"
+        >
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--firstPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ‹‹ 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--previousPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ‹ 
+            </a>
+          </li>
+          
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--nextPage"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               › 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--lastPage"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ›› 
+            </a>
+          </li>
+        </ul>
+      </div>
+    </ais-pagination>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`Pagination should add ais-Pagination--noRefinement CSS class on root when nbPages === 1 1`] = `
+<ng-component
+  testedWidget={[Function NgAisPagination]}
+>
+  <ais-instantsearch>
+    <ais-pagination>
+      <div
+        class="ais-Pagination ais-Pagination--noRefinement"
+        ng-reflect-ng-class="ais-Pagination,ais-Pagination-"
+      >
+        <ul
+          class="ais-Pagination-list"
+        >
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--firstPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ‹‹ 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--previousPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ‹ 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               1 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--nextPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               › 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--lastPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ›› 
+            </a>
+          </li>
+        </ul>
+      </div>
+    </ais-pagination>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`Pagination should not add ais-Pagination--noRefinement CSS class on root when nbPages > 1 1`] = `
+<ng-component
+  testedWidget={[Function NgAisPagination]}
+>
+  <ais-instantsearch>
+    <ais-pagination>
+      <div
+        class="ais-Pagination"
+        ng-reflect-ng-class="ais-Pagination,"
+      >
+        <ul
+          class="ais-Pagination-list"
+        >
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--firstPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ‹‹ 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--previousPage ais-Pagination-item--disabled"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ‹ 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--page ais-Pagination-item--selected"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               1 
+            </a>
+          </li>
+          <li
+            class="ais-Pagination-item ais-Pagination-item--page"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               2 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--nextPage"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               › 
+            </a>
+          </li>
+          
+          <li
+            class="ais-Pagination-item ais-Pagination-item--lastPage"
+          >
+            <a
+              class="ais-Pagination-link"
+              href="null"
+            >
+               ›› 
+            </a>
+          </li>
+        </ul>
+      </div>
+    </ais-pagination>
+  </ais-instantsearch>
+</ng-component>
+`;

--- a/src/pagination/__tests__/pagination.spec.ts
+++ b/src/pagination/__tests__/pagination.spec.ts
@@ -109,4 +109,16 @@ describe('Pagination', () => {
 
     expect(refine).not.toHaveBeenCalled();
   });
+  it('should not add ais-Pagination--noRefinement CSS class on root when nbPages > 1', () => {
+    const fixture = render({ nbPages: 2 });
+    expect(fixture).toMatchSnapshot();
+  });
+  it('should add ais-Pagination--noRefinement CSS class on root when nbPages === 1', () => {
+    const fixture = render({ nbPages: 1 });
+    expect(fixture).toMatchSnapshot();
+  });
+  it('should add ais-Pagination--noRefinement CSS class on root when nbPages === 0', () => {
+    const fixture = render({ nbPages: 0 });
+    expect(fixture).toMatchSnapshot();
+  });
 });

--- a/src/pagination/__tests__/pagination.spec.ts
+++ b/src/pagination/__tests__/pagination.spec.ts
@@ -111,14 +111,29 @@ describe('Pagination', () => {
   });
   it('should not add ais-Pagination--noRefinement CSS class on root when nbPages > 1', () => {
     const fixture = render({ nbPages: 2 });
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-pagination > .ais-Pagination--noRefinement'
+      )
+    ).toBeFalsy();
     expect(fixture).toMatchSnapshot();
   });
   it('should add ais-Pagination--noRefinement CSS class on root when nbPages === 1', () => {
     const fixture = render({ nbPages: 1 });
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-pagination > .ais-Pagination--noRefinement'
+      )
+    ).toBeTruthy();
     expect(fixture).toMatchSnapshot();
   });
   it('should add ais-Pagination--noRefinement CSS class on root when nbPages === 0', () => {
     const fixture = render({ nbPages: 0 });
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-pagination > .ais-Pagination--noRefinement'
+      )
+    ).toBeTruthy();
     expect(fixture).toMatchSnapshot();
   });
 });

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -8,7 +8,7 @@ import { parseNumberInput, noop } from '../utils';
 @Component({
   selector: 'ais-pagination',
   template: `
-    <div [class]="cx()">
+    <div [ngClass]="[cx()]">
       <ul [class]="cx('list')">
         <li
           *ngIf="showFirst"

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -8,7 +8,7 @@ import { parseNumberInput, noop } from '../utils';
 @Component({
   selector: 'ais-pagination',
   template: `
-    <div [ngClass]="[cx()]">
+    <div [ngClass]="[cx(), state.nbPages <= 1 ? cx('', 'noRefinement') : '']">
       <ul [class]="cx('list')">
         <li
           *ngIf="showFirst"


### PR DESCRIPTION
**Summary**

This adds ais-Pagination--noRefinement CSS class on root when nbPages <= 1

`ais-Pagination--noRefinement` is specificed here: https://instantsearch-css.netlify.com/widgets/pagination/

It is missing at the moment, which makes sharing CSS styles for demos harder.

The CSS class is enabled when nbPages <= 1. This is similar to the condition found in [React InstantSearch](https://github.com/algolia/react-instantsearch/blob/99ed761dc0536fafb884727ed593ee0906b80b7a/packages/react-instantsearch-core/src/connectors/connectPagination.js#L67)


**Result**
No visible effect