### PR TITLE
chore(deps): update InstantSearch.js to 3.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "eslint-config-prettier": "3.6.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-prettier": "3.0.1",
-    "instantsearch.js": "3.5.3",
+    "instantsearch.js": "3.5.4",
     "jest": "23.6.0",
     "jest-preset-angular": "6.0.2",
     "ng-packagr": "4.7.0",
@@ -146,6 +146,6 @@
     "@angular/core": ">=5.0.0 <8.0.0",
     "@angular/platform-browser": ">=5.0.0 <8.0.0",
     "@angular/platform-browser-dynamic": ">=5.0.0 <8.0.0",
-    "instantsearch.js": "^3.5.3"
+    "instantsearch.js": "^3.5.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,10 +3347,10 @@ instantsearch.css@^7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-3.5.3.tgz#da85f306874fb1b588f886de5a38331bc689b03f"
-  integrity sha512-QEXkKCJtBIQK5cJMGlkWdyM+aBZFV+8YwxwhN/qcebPJEA19Mwq9LlsFpMSv7UEw42Xx0wEpHuLVUtDqEC7YIQ==
+instantsearch.js@3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-3.5.4.tgz#59f8e07313300448771b1f8ff92f15e75f2130e5"
+  integrity sha512-hvBzKPwbk/jde1xS3vEQJfhYBq2NWuWxhzr3P3p/ZX5Lf5XIUjWalNX3oHqEW2iYisMdcxWbVkZxpvL/ACHzNw==
   dependencies:
     algoliasearch-helper "^2.26.0"
     classnames "^2.2.5"


### PR DESCRIPTION
This PR updates InstantSearch.js to [3.5.4](https://github.com/algolia/instantsearch.js/blob/develop/CHANGELOG.md#354-2019-07-01).