### PR TITLE
fix: add ais-RefinementList--noRefinement CSS class on root when items === []

### DIFF
--- a/src/refinement-list/__tests__/__snapshots__/refinement-list.spec.ts.snap
+++ b/src/refinement-list/__tests__/__snapshots__/refinement-list.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`RefinementList renders markup with state 1`] = `
       
       <div
         class="ais-RefinementList"
+        ng-reflect-ng-class="ais-RefinementList,"
       >
         
         <ul
@@ -163,7 +164,8 @@ exports[`RefinementList renders markup without state 1`] = `
     <ais-refinement-list>
       
       <div
-        class="ais-RefinementList"
+        class="ais-RefinementList ais-RefinementList--noRefinement"
+        ng-reflect-ng-class="ais-RefinementList,ais-Refinem"
       >
         
         <ul
@@ -187,6 +189,7 @@ exports[`RefinementList should apply \`transformItems\` if specified 1`] = `
       
       <div
         class="ais-RefinementList"
+        ng-reflect-ng-class="ais-RefinementList,"
       >
         
         <ul
@@ -340,6 +343,87 @@ exports[`RefinementList should be hidden with autoHideContainer 1`] = `
   <ais-instantsearch>
     <ais-refinement-list>
       
+    </ais-refinement-list>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`RefinementList should not use ais-RefinementList--noRefinement when items is not empty 1`] = `
+<ng-component
+  testedWidget={[Function NgAisRefinementList]}
+>
+  <ais-instantsearch>
+    <ais-refinement-list>
+      
+      <div
+        class="ais-RefinementList"
+        ng-reflect-ng-class="ais-RefinementList,"
+      >
+        
+        <ul
+          class="ais-RefinementList-list"
+        >
+          
+          <li
+            class="ais-RefinementList-item"
+          >
+            <label
+              class="ais-RefinementList-label"
+            >
+              <input
+                class="ais-RefinementList-checkbox"
+                type="checkbox"
+                value="foo"
+              />
+              <span
+                class="ais-RefinementList-labelText"
+              >
+                <ais-highlight
+                  attribute="highlighted"
+                  ng-reflect-attribute="highlighted"
+                  ng-reflect-hit="[object Object]"
+                >
+                  <span
+                    class="ais-Highlight"
+                  >
+                    foo
+                  </span>
+                </ais-highlight>
+              </span>
+              <span
+                class="ais-RefinementList-count"
+              >
+                100
+              </span>
+            </label>
+          </li>
+        </ul>
+        
+      </div>
+    </ais-refinement-list>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`RefinementList should use ais-RefinementList--noRefinement when items is empty 1`] = `
+<ng-component
+  testedWidget={[Function NgAisRefinementList]}
+>
+  <ais-instantsearch>
+    <ais-refinement-list>
+      
+      <div
+        class="ais-RefinementList ais-RefinementList--noRefinement"
+        ng-reflect-ng-class="ais-RefinementList,ais-Refinem"
+      >
+        
+        <ul
+          class="ais-RefinementList-list"
+        >
+          
+        </ul>
+        
+      </div>
     </ais-refinement-list>
   </ais-instantsearch>
 </ng-component>

--- a/src/refinement-list/__tests__/refinement-list.spec.ts
+++ b/src/refinement-list/__tests__/refinement-list.spec.ts
@@ -289,7 +289,33 @@ describe('RefinementList', () => {
     const fixture = render({ items: [] });
     fixture.componentInstance.testedWidget.autoHideContainer = true;
     fixture.detectChanges();
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-refinement-list > .ais-RefinementList'
+      )
+    ).toBeFalsy();
+    expect(fixture).toMatchSnapshot();
+  });
 
+  it('should use ais-RefinementList--noRefinement when items is empty', () => {
+    const fixture = render({ items: [] });
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-refinement-list > .ais-RefinementList--noRefinement'
+      )
+    ).toBeTruthy();
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should not use ais-RefinementList--noRefinement when items is not empty', () => {
+    const fixture = render({
+      items: [{ label: 'foo', count: 100, value: 'foo', isRefined: false }],
+    });
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-refinement-list > .ais-RefinementList--noRefinement'
+      )
+    ).toBeFalsy();
     expect(fixture).toMatchSnapshot();
   });
 });

--- a/src/refinement-list/refinement-list.ts
+++ b/src/refinement-list/refinement-list.ts
@@ -30,7 +30,10 @@ export type RefinementListState = {
   selector: 'ais-refinement-list',
   template: `
     <div
-      [class]="cx()"
+      [ngClass]="[
+        cx(),
+        state.items.length === 0 ? cx('', 'noRefinement') : ''
+      ]"
       *ngIf="!isHidden"
     >
       <div


### PR DESCRIPTION
**Summary**

This adds `ais-RefinementList--noRefinement` CSS class on root when items === [].
This is specified in https://instantsearch-css.netlify.com/widgets/refinement-list/

This similar to InstantSearch.JS implementation:
https://github.com/algolia/instantsearch.js/blob/b6ee2596d353ea692d91929759bc2b2fe34945c7/src/components/RefinementList/RefinementList.js#L226-L228

Vue InstantSearch is using `canRefine` which is slightly different, and
means noRefinement class is never applied while searching for facet values.
https://github.com/algolia/instantsearch.js/blob/b6ee2596d353ea692d91929759bc2b2fe34945c7/src/connectors/refinement-list/connectRefinementList.js#L193

**Result**

nothing visible.
