### PR TITLE
 fix: add ais-RangeInput--noRefinement CSS class on root when min === max

### DIFF
--- a/src/range-input/__tests__/__snapshots__/range-input.spec.ts.snap
+++ b/src/range-input/__tests__/__snapshots__/range-input.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`RangeInput renders markup with state 1`] = `
     <ais-range-input>
       <div
         class="ais-RangeInput"
+        ng-reflect-ng-class="ais-RangeInput"
       >
         <form
           class="ais-RangeInput-form"
@@ -74,6 +75,7 @@ exports[`RangeInput renders markup without state 1`] = `
     <ais-range-input>
       <div
         class="ais-RangeInput"
+        ng-reflect-ng-class="ais-RangeInput"
       >
         <form
           class="ais-RangeInput-form"

--- a/src/range-input/__tests__/__snapshots__/range-input.spec.ts.snap
+++ b/src/range-input/__tests__/__snapshots__/range-input.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`RangeInput renders markup with state 1`] = `
     <ais-range-input>
       <div
         class="ais-RangeInput"
-        ng-reflect-ng-class="ais-RangeInput"
+        ng-reflect-ng-class="ais-RangeInput,"
       >
         <form
           class="ais-RangeInput-form"
@@ -74,8 +74,8 @@ exports[`RangeInput renders markup without state 1`] = `
   <ais-instantsearch>
     <ais-range-input>
       <div
-        class="ais-RangeInput"
-        ng-reflect-ng-class="ais-RangeInput"
+        class="ais-RangeInput ais-RangeInput--noRefinement"
+        ng-reflect-ng-class="ais-RangeInput,ais-RangeInput-"
       >
         <form
           class="ais-RangeInput-form"
@@ -118,6 +118,140 @@ exports[`RangeInput renders markup without state 1`] = `
               min="undefined"
               ng-reflect-ng-class="ais-RangeInput-input,ais-Range"
               placeholder="undefined"
+              step="1"
+              type="number"
+            />
+          </label>
+          <button
+            class="ais-RangeInput-submit"
+          >
+             Go 
+          </button>
+        </form>
+      </div>
+    </ais-range-input>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`RangeInput should not use ais-RangeInput--noRefinement when min < max 1`] = `
+<ng-component
+  testedWidget={[Function NgAisRangeInput]}
+>
+  <ais-instantsearch>
+    <ais-range-input>
+      <div
+        class="ais-RangeInput"
+        ng-reflect-ng-class="ais-RangeInput,"
+      >
+        <form
+          class="ais-RangeInput-form"
+          novalidate=""
+        >
+          <label
+            class="ais-RangeInput-label"
+          >
+            <span
+              class="ais-RangeInput-currency"
+            >
+              $
+            </span>
+            <input
+              class="ais-RangeInput-input ais-RangeInput-input--min"
+              max="100"
+              min="0"
+              ng-reflect-ng-class="ais-RangeInput-input,ais-Range"
+              placeholder="0"
+              step="1"
+              type="number"
+            />
+          </label>
+          <span
+            class="ais-RangeInput-separator"
+          >
+            to
+          </span>
+          <label
+            class="ais-RangeInput-label"
+          >
+            <span
+              class="ais-RangeInput-currency"
+            >
+              $
+            </span>
+            <input
+              class="ais-RangeInput-input ais-RangeInput-input--max"
+              max="100"
+              min="0"
+              ng-reflect-ng-class="ais-RangeInput-input,ais-Range"
+              placeholder="100"
+              step="1"
+              type="number"
+            />
+          </label>
+          <button
+            class="ais-RangeInput-submit"
+          >
+             Go 
+          </button>
+        </form>
+      </div>
+    </ais-range-input>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`RangeInput should use ais-RangeInput--noRefinement when min === max 1`] = `
+<ng-component
+  testedWidget={[Function NgAisRangeInput]}
+>
+  <ais-instantsearch>
+    <ais-range-input>
+      <div
+        class="ais-RangeInput ais-RangeInput--noRefinement"
+        ng-reflect-ng-class="ais-RangeInput,ais-RangeInput-"
+      >
+        <form
+          class="ais-RangeInput-form"
+          novalidate=""
+        >
+          <label
+            class="ais-RangeInput-label"
+          >
+            <span
+              class="ais-RangeInput-currency"
+            >
+              $
+            </span>
+            <input
+              class="ais-RangeInput-input ais-RangeInput-input--min"
+              max="0"
+              min="0"
+              ng-reflect-ng-class="ais-RangeInput-input,ais-Range"
+              placeholder="0"
+              step="1"
+              type="number"
+            />
+          </label>
+          <span
+            class="ais-RangeInput-separator"
+          >
+            to
+          </span>
+          <label
+            class="ais-RangeInput-label"
+          >
+            <span
+              class="ais-RangeInput-currency"
+            >
+              $
+            </span>
+            <input
+              class="ais-RangeInput-input ais-RangeInput-input--max"
+              max="0"
+              min="0"
+              ng-reflect-ng-class="ais-RangeInput-input,ais-Range"
+              placeholder="0"
               step="1"
               type="number"
             />

--- a/src/range-input/__tests__/range-input.spec.ts
+++ b/src/range-input/__tests__/range-input.spec.ts
@@ -122,4 +122,42 @@ describe('RangeInput', () => {
     const fixture = render();
     expect(fixture.componentInstance.testedWidget.step).toEqual(100);
   });
+
+  it('should use ais-RangeInput--noRefinement when min === max', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
+    const fixture = render({
+      range: { min: 0, max: 0 },
+      start: [0, 100],
+      refine: jest.fn(),
+    });
+    expect(fixture).toMatchSnapshot();
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-range-input > .ais-RangeInput--noRefinement'
+      )
+    ).toBeTruthy();
+  });
+
+  it('should not use ais-RangeInput--noRefinement when min < max', () => {
+    const render = createRenderer({
+      defaultState,
+      template: '<ais-range-input></ais-range-input>',
+      TestedWidget: NgAisRangeInput,
+    });
+    const fixture = render({
+      range: { min: 0, max: 100 },
+      start: [0, 100],
+      refine: jest.fn(),
+    });
+    expect(fixture).toMatchSnapshot();
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-range-input > .ais-RangeInput--noRefinement'
+      )
+    ).toBeFalsy();
+  });
 });

--- a/src/range-input/range-input.ts
+++ b/src/range-input/range-input.ts
@@ -91,7 +91,7 @@ export class NgAisRangeInput extends BaseWidget {
   }
 
   get canRefine() {
-    return this.state.range && this.state.range.min !== this.state.range.max;
+    return this.state.range.min !== this.state.range.max;
   }
 
   public state: NumericRangeState = {

--- a/src/range-input/range-input.ts
+++ b/src/range-input/range-input.ts
@@ -14,7 +14,7 @@ export type NumericRangeState = {
 @Component({
   selector: 'ais-range-input',
   template: `
-    <div [class]="cx()">
+    <div [ngClass]="[cx()]">
       <form
         [class]="cx('form')"
         (submit)="handleSubmit($event)"

--- a/src/range-input/range-input.ts
+++ b/src/range-input/range-input.ts
@@ -14,7 +14,10 @@ export type NumericRangeState = {
 @Component({
   selector: 'ais-range-input',
   template: `
-    <div [ngClass]="[cx()]">
+    <div [ngClass]="[
+        cx(), 
+        !canRefine ? cx('', 'noRefinement') : ''
+      ]">
       <form
         [class]="cx('form')"
         (submit)="handleSubmit($event)"
@@ -85,6 +88,10 @@ export class NgAisRangeInput extends BaseWidget {
   get step() {
     const precision = parseNumberInput(this.precision);
     return 1 / Math.pow(10, precision);
+  }
+
+  get canRefine() {
+    return this.state.range && this.state.range.min !== this.state.range.max;
   }
 
   public state: NumericRangeState = {


### PR DESCRIPTION
**Summary**

This adds `ais-RangeInput--noRefinement` CSS class on root when min === max.
This is specified in https://instantsearch-css.netlify.com/widgets/range-input/

Currently every flavour is doing it its won way:

[InstantSearch.JS](https://github.com/algolia/instantsearch.js/blob/b6ee2596d353ea692d91929759bc2b2fe34945c7/src/components/RangeInput/RangeInput.js#L40) is the following condition: `Boolean(min || max)`.

[React InstantSearch](https://github.com/algolia/react-instantsearch/blob/master/packages/react-instantsearch-core/src/connectors/connectRange.js#L247) is using facet count to enable this CSS class but this is not exposed in InstantSearch Connector.

[Vue InstantSearch](https://github.com/algolia/vue-instantsearch/blob/ceeecefa9948526f0518a00eb68563298fcdb7bb/src/components/RangeInput.vue#L62) enables it when `!canRefine`, where `canRefine = state.range && state.range.min !== state.range.max`.

This PR uses the same condition as Vue InstantSearch.

