### PR TITLE
fix: add ais-RatingMenu--noRefinement CSS class on root when items === []

### DIFF
--- a/src/rating-menu/__tests__/__snapshots__/rating-menu.spec.ts.snap
+++ b/src/rating-menu/__tests__/__snapshots__/rating-menu.spec.ts.snap
@@ -12,6 +12,128 @@ exports[`StarRating should be hidden with autoHideContainer 1`] = `
 </ng-component>
 `;
 
+exports[`StarRating should not use ais-RatingMenu--noRefinement when items is not empty 1`] = `
+<ng-component
+  testedWidget={[Function NgAisRatingMenu]}
+>
+  <ais-instantsearch>
+    <ais-rating-menu>
+      
+      <div
+        class="ais-RatingMenu"
+        ng-reflect-ng-class="ais-RatingMenu,"
+      >
+        <svg
+          style="display:none;"
+        >
+          <symbol
+            height="24"
+            id="ais-StarRating-starSymbol"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M12 .288l2.833 8.718h9.167l-7.417 5.389 2.833 8.718-7.416-5.388-7.417 5.388 2.833-8.718-7.416-5.389h9.167z"
+            />
+          </symbol>
+          <symbol
+            height="24"
+            id="ais-StarRating-starEmptySymbol"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M12 6.76l1.379 4.246h4.465l-3.612 2.625 1.379 4.246-3.611-2.625-3.612 2.625 1.379-4.246-3.612-2.625h4.465l1.38-4.246zm0-6.472l-2.833 8.718h-9.167l7.416 5.389-2.833 8.718 7.417-5.388 7.416 5.388-2.833-8.718 7.417-5.389h-9.167l-2.833-8.718z"
+            />
+          </symbol>
+        </svg>
+        <ul
+          class="ais-RatingMenu-list"
+        >
+          
+          <li
+            class="ais-RatingMenu-item"
+          >
+            <a
+              class="ais-RatingMenu-link"
+              href=""
+            >
+              
+              <svg
+                aria-hidden="true"
+                class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+              >
+                
+                <use
+                  xlink:href="#ais-StarRating-starSymbol"
+                />
+                
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+              >
+                
+                
+                <use
+                  xlink:href="#ais-StarRating-starEmptySymbol"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+              >
+                
+                
+                <use
+                  xlink:href="#ais-StarRating-starEmptySymbol"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+              >
+                
+                
+                <use
+                  xlink:href="#ais-StarRating-starEmptySymbol"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+              >
+                
+                
+                <use
+                  xlink:href="#ais-StarRating-starEmptySymbol"
+                />
+              </svg>
+              <span
+                aria-hidden="true"
+                class="ais-RatingMenu-label"
+              >
+                & Up
+              </span>
+              <span
+                class="ais-RatingMenu-count"
+              >
+                100
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </ais-rating-menu>
+  </ais-instantsearch>
+</ng-component>
+`;
+
 exports[`StarRating should render with state 1`] = `
 <ng-component
   testedWidget={[Function NgAisRatingMenu]}
@@ -21,6 +143,7 @@ exports[`StarRating should render with state 1`] = `
       
       <div
         class="ais-RatingMenu"
+        ng-reflect-ng-class="ais-RatingMenu,"
       >
         <svg
           style="display:none;"
@@ -369,7 +492,54 @@ exports[`StarRating should render without state 1`] = `
     <ais-rating-menu>
       
       <div
-        class="ais-RatingMenu"
+        class="ais-RatingMenu ais-RatingMenu--noRefinement"
+        ng-reflect-ng-class="ais-RatingMenu,ais-RatingMenu-"
+      >
+        <svg
+          style="display:none;"
+        >
+          <symbol
+            height="24"
+            id="ais-StarRating-starSymbol"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M12 .288l2.833 8.718h9.167l-7.417 5.389 2.833 8.718-7.416-5.388-7.417 5.388 2.833-8.718-7.416-5.389h9.167z"
+            />
+          </symbol>
+          <symbol
+            height="24"
+            id="ais-StarRating-starEmptySymbol"
+            viewBox="0 0 24 24"
+            width="24"
+          >
+            <path
+              d="M12 6.76l1.379 4.246h4.465l-3.612 2.625 1.379 4.246-3.611-2.625-3.612 2.625 1.379-4.246-3.612-2.625h4.465l1.38-4.246zm0-6.472l-2.833 8.718h-9.167l7.416 5.389-2.833 8.718 7.417-5.388 7.416 5.388-2.833-8.718 7.417-5.389h-9.167l-2.833-8.718z"
+            />
+          </symbol>
+        </svg>
+        <ul
+          class="ais-RatingMenu-list"
+        >
+          
+        </ul>
+      </div>
+    </ais-rating-menu>
+  </ais-instantsearch>
+</ng-component>
+`;
+
+exports[`StarRating should use ais-RatingMenu--noRefinement when items is empty 1`] = `
+<ng-component
+  testedWidget={[Function NgAisRatingMenu]}
+>
+  <ais-instantsearch>
+    <ais-rating-menu>
+      
+      <div
+        class="ais-RatingMenu ais-RatingMenu--noRefinement"
+        ng-reflect-ng-class="ais-RatingMenu,ais-RatingMenu-"
       >
         <svg
           style="display:none;"

--- a/src/rating-menu/__tests__/rating-menu.spec.ts
+++ b/src/rating-menu/__tests__/rating-menu.spec.ts
@@ -46,4 +46,28 @@ describe('StarRating', () => {
 
     expect(fixture).toMatchSnapshot();
   });
+
+  it('should use ais-RatingMenu--noRefinement when items is empty', () => {
+    const fixture = render({ items: [] });
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-rating-menu > .ais-RatingMenu--noRefinement'
+      )
+    ).toBeTruthy();
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('should not use ais-RatingMenu--noRefinement when items is not empty', () => {
+    const fixture = render({
+      items: [
+        { name: '1', stars: [true, false, false, false, false], count: 100 },
+      ],
+    });
+    expect(
+      fixture.debugElement.nativeElement.querySelector(
+        'ais-rating-menu > .ais-RatingMenu--noRefinement'
+      )
+    ).toBeFalsy();
+    expect(fixture).toMatchSnapshot();
+  });
 });

--- a/src/rating-menu/rating-menu.ts
+++ b/src/rating-menu/rating-menu.ts
@@ -24,7 +24,10 @@ export type RatingMenuState = {
   selector: 'ais-rating-menu',
   template: `
     <div
-      [class]="cx()"
+      [ngClass]="[
+        cx(),
+        state.items.length === 0 ? cx('', 'noRefinement') : ''
+      ]"
       *ngIf="!isHidden"
     >
       <svg style="display:none;">


### PR DESCRIPTION
**Summary**

This adds `ais-StarRating--noRefinement` CSS class on root when items === [].
This is specified in https://instantsearch-css.netlify.com/widgets/rating-menu/

This similar to InstantSearch.JS implementation, which is using the RefinementList component:
https://github.com/algolia/instantsearch.js/blob/b6ee2596d353ea692d91929759bc2b2fe34945c7/src/components/RefinementList/RefinementList.js#L226-L228

Vue InstantSearch does not implement it: https://github.com/algolia/vue-instantsearch/blob/aa7ba065d897b9a5654b04f6bbd23818eaf83baa/src/components/RatingMenu.vue#L4

React InstantSearch is using facet count https://github.com/algolia/react-instantsearch/blob/05a85b61d6e3e3e946c07d05f26fe38289c9920a/packages/react-instantsearch-core/src/connectors/connectRange.js#L247




