### PR TITLE
fix(StarRating): fix overflowing symbols

### DIFF
--- a/src/rating-menu/__tests__/__snapshots__/rating-menu.spec.ts.snap
+++ b/src/rating-menu/__tests__/__snapshots__/rating-menu.spec.ts.snap
@@ -58,7 +58,9 @@ exports[`StarRating should not use ais-RatingMenu--noRefinement when items is no
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -69,7 +71,9 @@ exports[`StarRating should not use ais-RatingMenu--noRefinement when items is no
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -80,7 +84,9 @@ exports[`StarRating should not use ais-RatingMenu--noRefinement when items is no
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -91,7 +97,9 @@ exports[`StarRating should not use ais-RatingMenu--noRefinement when items is no
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -102,7 +110,9 @@ exports[`StarRating should not use ais-RatingMenu--noRefinement when items is no
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -176,7 +186,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -187,7 +199,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -198,7 +212,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -209,7 +225,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -220,7 +238,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -252,7 +272,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -263,7 +285,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -274,7 +298,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -285,7 +311,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -296,7 +324,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -328,7 +358,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -339,7 +371,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -350,7 +384,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -361,7 +397,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -372,7 +410,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -404,7 +444,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--full"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 <use
@@ -415,7 +457,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -426,7 +470,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -437,7 +483,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 
@@ -448,7 +496,9 @@ exports[`StarRating should render with state 1`] = `
               <svg
                 aria-hidden="true"
                 class="ais-RatingMenu-starIcon ais-RatingMenu-starIcon--empty"
+                height="24"
                 ng-reflect-ng-class="ais-RatingMenu-starIcon ais-Ra"
+                width="24"
               >
                 
                 

--- a/src/rating-menu/__tests__/__snapshots__/rating-menu.spec.ts.snap
+++ b/src/rating-menu/__tests__/__snapshots__/rating-menu.spec.ts.snap
@@ -27,20 +27,16 @@ exports[`StarRating should not use ais-RatingMenu--noRefinement when items is no
           style="display:none;"
         >
           <symbol
-            height="24"
             id="ais-StarRating-starSymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 .288l2.833 8.718h9.167l-7.417 5.389 2.833 8.718-7.416-5.388-7.417 5.388 2.833-8.718-7.416-5.389h9.167z"
             />
           </symbol>
           <symbol
-            height="24"
             id="ais-StarRating-starEmptySymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 6.76l1.379 4.246h4.465l-3.612 2.625 1.379 4.246-3.611-2.625-3.612 2.625 1.379-4.246-3.612-2.625h4.465l1.38-4.246zm0-6.472l-2.833 8.718h-9.167l7.416 5.389-2.833 8.718 7.417-5.388 7.416 5.388-2.833-8.718 7.417-5.389h-9.167l-2.833-8.718z"
@@ -149,20 +145,16 @@ exports[`StarRating should render with state 1`] = `
           style="display:none;"
         >
           <symbol
-            height="24"
             id="ais-StarRating-starSymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 .288l2.833 8.718h9.167l-7.417 5.389 2.833 8.718-7.416-5.388-7.417 5.388 2.833-8.718-7.416-5.389h9.167z"
             />
           </symbol>
           <symbol
-            height="24"
             id="ais-StarRating-starEmptySymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 6.76l1.379 4.246h4.465l-3.612 2.625 1.379 4.246-3.611-2.625-3.612 2.625 1.379-4.246-3.612-2.625h4.465l1.38-4.246zm0-6.472l-2.833 8.718h-9.167l7.416 5.389-2.833 8.718 7.417-5.388 7.416 5.388-2.833-8.718 7.417-5.389h-9.167l-2.833-8.718z"
@@ -499,20 +491,16 @@ exports[`StarRating should render without state 1`] = `
           style="display:none;"
         >
           <symbol
-            height="24"
             id="ais-StarRating-starSymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 .288l2.833 8.718h9.167l-7.417 5.389 2.833 8.718-7.416-5.388-7.417 5.388 2.833-8.718-7.416-5.389h9.167z"
             />
           </symbol>
           <symbol
-            height="24"
             id="ais-StarRating-starEmptySymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 6.76l1.379 4.246h4.465l-3.612 2.625 1.379 4.246-3.611-2.625-3.612 2.625 1.379-4.246-3.612-2.625h4.465l1.38-4.246zm0-6.472l-2.833 8.718h-9.167l7.416 5.389-2.833 8.718 7.417-5.388 7.416 5.388-2.833-8.718 7.417-5.389h-9.167l-2.833-8.718z"
@@ -545,20 +533,16 @@ exports[`StarRating should use ais-RatingMenu--noRefinement when items is empty 
           style="display:none;"
         >
           <symbol
-            height="24"
             id="ais-StarRating-starSymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 .288l2.833 8.718h9.167l-7.417 5.389 2.833 8.718-7.416-5.388-7.417 5.388 2.833-8.718-7.416-5.389h9.167z"
             />
           </symbol>
           <symbol
-            height="24"
             id="ais-StarRating-starEmptySymbol"
             viewBox="0 0 24 24"
-            width="24"
           >
             <path
               d="M12 6.76l1.379 4.246h4.465l-3.612 2.625 1.379 4.246-3.611-2.625-3.612 2.625 1.379-4.246-3.612-2.625h4.465l1.38-4.246zm0-6.472l-2.833 8.718h-9.167l7.416 5.389-2.833 8.718 7.417-5.388 7.416 5.388-2.833-8.718 7.417-5.389h-9.167l-2.833-8.718z"

--- a/src/rating-menu/rating-menu.ts
+++ b/src/rating-menu/rating-menu.ts
@@ -57,6 +57,8 @@ export type RatingMenuState = {
             (click)="handleClick($event, item.value)"
           >
             <svg
+              width="24"
+              height="24"
               *ngFor="let star of item.stars"
               [ngClass]="cx('starIcon') + ' ' + (star ? cx('starIcon', 'full') : cx('starIcon', 'empty'))"
               aria-hidden="true"

--- a/src/rating-menu/rating-menu.ts
+++ b/src/rating-menu/rating-menu.ts
@@ -34,16 +34,12 @@ export type RatingMenuState = {
         <symbol
           id="ais-StarRating-starSymbol"
           viewBox="0 0 24 24"
-          width="24"
-          height="24"
         >
           <path d="M12 .288l2.833 8.718h9.167l-7.417 5.389 2.833 8.718-7.416-5.388-7.417 5.388 2.833-8.718-7.416-5.389h9.167z"/>
         </symbol>
         <symbol
           id="ais-StarRating-starEmptySymbol"
           viewBox="0 0 24 24"
-          width="24"
-          height="24"
         >
           <path d="M12 6.76l1.379 4.246h4.465l-3.612 2.625 1.379 4.246-3.611-2.625-3.612 2.625 1.379-4.246-3.612-2.625h4.465l1.38-4.246zm0-6.472l-2.833 8.718h-9.167l7.416 5.389-2.833 8.718 7.417-5.388 7.416 5.388-2.833-8.718 7.417-5.389h-9.167l-2.833-8.718z"/>
         </symbol>


### PR DESCRIPTION
**Summary**

This is fixing a sizing/positioning issue on RatingMenu.
I found that it came from the width and height we are setting on the
symbols.

It seems they've always been there https://github.com/algolia/angular-instantsearch/commit/fa8fe63ef9d2bbad78bc2e34f6b0e998a811f8d3
but they were not specified in [InstantSearch.css](https://instantsearch-css.netlify.com/widgets/rating-menu/)

This will need to be ported to v2

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->



**Result**

Before

![before](https://user-images.githubusercontent.com/2982512/61638767-5e630700-ac9a-11e9-90a6-47dc510201ce.png)

After
![after](https://user-images.githubusercontent.com/2982512/61639122-2ad4ac80-ac9b-11e9-91fb-baa20939aa6e.png)

Closes #658 
