### PR TITLE
feat: add possibility to set params for the client

### DIFF
--- a/src/__tests__/create-ssr-algolia-client.spec.ts
+++ b/src/__tests__/create-ssr-algolia-client.spec.ts
@@ -21,6 +21,7 @@ describe('Create SSR', () => {
       HttpHeaders: null,
       makeStateKey: null,
       transferState: null,
+      options: {},
     });
     expect(addAlgoliaAgent).toHaveBeenCalledTimes(3);
     expect(addAlgoliaAgent).toHaveBeenCalledWith(

--- a/src/__tests__/create-ssr-algolia-client.spec.ts
+++ b/src/__tests__/create-ssr-algolia-client.spec.ts
@@ -1,7 +1,5 @@
 import { createSSRSearchClient } from '../create-ssr-algolia-client';
 import * as algoliasearchProxy from 'algoliasearch/index';
-import { VERSION } from '../version';
-import { VERSION as AngularVersion } from '@angular/core';
 
 jest.mock('algoliasearch/index');
 
@@ -13,7 +11,7 @@ describe('Create SSR', () => {
         addAlgoliaAgent,
       };
     });
-  
+
     createSSRSearchClient({
       appId: 'appId',
       apiKey: 'apiKey',
@@ -22,10 +20,10 @@ describe('Create SSR', () => {
       makeStateKey: null,
       transferState: null,
     });
-  
+
     expect(algoliasearchProxy).toHaveBeenCalledWith('appId', 'apiKey', {});
   });
-  
+
   it('forwards the options to the search client', () => {
     const addAlgoliaAgent = jest.fn();
     algoliasearchProxy.mockImplementation(() => {
@@ -33,7 +31,7 @@ describe('Create SSR', () => {
         addAlgoliaAgent,
       };
     });
-  
+
     createSSRSearchClient({
       appId: 'appId',
       apiKey: 'apiKey',
@@ -45,7 +43,7 @@ describe('Create SSR', () => {
       makeStateKey: null,
       transferState: null,
     });
-  
+
     expect(algoliasearchProxy).toHaveBeenCalledWith('appId', 'apiKey', {
       queryParameters: {},
     });

--- a/src/__tests__/create-ssr-algolia-client.spec.ts
+++ b/src/__tests__/create-ssr-algolia-client.spec.ts
@@ -1,9 +1,39 @@
 import { createSSRSearchClient } from '../create-ssr-algolia-client';
 import * as algoliasearchProxy from 'algoliasearch/index';
+import { VERSION } from '../version';
+import { VERSION as AngularVersion } from '@angular/core';
 
 jest.mock('algoliasearch/index');
 
 describe('Create SSR', () => {
+  it('passes the User-Agent', () => {
+    const addAlgoliaAgent = jest.fn();
+    algoliasearchProxy.mockImplementation(() => {
+      return {
+        addAlgoliaAgent,
+      };
+    });
+
+    const ssrClient = createSSRSearchClient({
+      appId: 'test',
+      apiKey: 'test',
+      httpClient: null,
+      HttpHeaders: null,
+      makeStateKey: null,
+      transferState: null,
+    });
+    expect(addAlgoliaAgent).toHaveBeenCalledTimes(3);
+    expect(addAlgoliaAgent).toHaveBeenCalledWith(
+      `angular (${AngularVersion.full})`
+    );
+    expect(addAlgoliaAgent).toHaveBeenCalledWith(
+      `angular-instantsearch (${VERSION})`
+    );
+    expect(addAlgoliaAgent).toHaveBeenCalledWith(
+      `angular-instantsearch-server (${VERSION})`
+    );
+  });
+
   it('forwards the default options to the search client', () => {
     const addAlgoliaAgent = jest.fn();
     algoliasearchProxy.mockImplementation(() => {

--- a/src/__tests__/create-ssr-algolia-client.spec.ts
+++ b/src/__tests__/create-ssr-algolia-client.spec.ts
@@ -6,32 +6,48 @@ import { VERSION as AngularVersion } from '@angular/core';
 jest.mock('algoliasearch/index');
 
 describe('Create SSR', () => {
-  it('passes the User-Agent', () => {
+  it('forwards the default options to the search client', () => {
     const addAlgoliaAgent = jest.fn();
     algoliasearchProxy.mockImplementation(() => {
       return {
         addAlgoliaAgent,
       };
     });
-
-    const ssrClient = createSSRSearchClient({
-      appId: 'test',
-      apiKey: 'test',
+  
+    createSSRSearchClient({
+      appId: 'appId',
+      apiKey: 'apiKey',
       httpClient: null,
       HttpHeaders: null,
       makeStateKey: null,
       transferState: null,
-      options: {},
     });
-    expect(addAlgoliaAgent).toHaveBeenCalledTimes(3);
-    expect(addAlgoliaAgent).toHaveBeenCalledWith(
-      `angular (${AngularVersion.full})`
-    );
-    expect(addAlgoliaAgent).toHaveBeenCalledWith(
-      `angular-instantsearch (${VERSION})`
-    );
-    expect(addAlgoliaAgent).toHaveBeenCalledWith(
-      `angular-instantsearch-server (${VERSION})`
-    );
+  
+    expect(algoliasearchProxy).toHaveBeenCalledWith('appId', 'apiKey', {});
+  });
+  
+  it('forwards the options to the search client', () => {
+    const addAlgoliaAgent = jest.fn();
+    algoliasearchProxy.mockImplementation(() => {
+      return {
+        addAlgoliaAgent,
+      };
+    });
+  
+    createSSRSearchClient({
+      appId: 'appId',
+      apiKey: 'apiKey',
+      options: {
+        queryParameters: {},
+      },
+      httpClient: null,
+      HttpHeaders: null,
+      makeStateKey: null,
+      transferState: null,
+    });
+  
+    expect(algoliasearchProxy).toHaveBeenCalledWith('appId', 'apiKey', {
+      queryParameters: {},
+    });
   });
 });

--- a/src/create-ssr-algolia-client.ts
+++ b/src/create-ssr-algolia-client.ts
@@ -14,6 +14,7 @@ export function createSSRAlgoliaClient({
   HttpHeaders,
   transferState,
   makeStateKey,
+  options = {},
 }) {
   console.warn(
     '`createSSRAlgoliaClient` is deprecated in favor of `createSSRSearchClient` to be plugged to `searchClient`.'
@@ -27,6 +28,7 @@ export function createSSRAlgoliaClient({
       HttpHeaders,
       transferState,
       makeStateKey,
+      options,
     });
 }
 
@@ -37,8 +39,9 @@ export function createSSRSearchClient({
   HttpHeaders,
   transferState,
   makeStateKey,
+  options = {},
 }) {
-  const client = algoliasearch(appId, apiKey, {});
+  const client = algoliasearch(appId, apiKey, options);
   client.addAlgoliaAgent(`angular (${AngularVersion.full})`);
   client.addAlgoliaAgent(`angular-instantsearch (${VERSION})`);
   client.addAlgoliaAgent(`angular-instantsearch-server (${VERSION})`);


### PR DESCRIPTION
This would be needed for us to put a proxy between Algolia and our frontend to track impressions more effectively on the backend.

**Summary**
I want to set up `hosts.read` and `hosts.write` to setup my proxy host, which will track product ids returned for a set of filters and etc.

Additionally, we will use more than one Algolia cluster so my `proxy` would balance between them without client modifications.

**Result**
