### PR TITLE
feat(ssr): forward options to search client

### DIFF
--- a/src/__tests__/create-ssr-search-client.spec.ts
+++ b/src/__tests__/create-ssr-search-client.spec.ts
@@ -35,4 +35,49 @@ describe('createSSRSearchClient', () => {
       `angular-instantsearch-server (${VERSION})`
     );
   });
+
+  it('forwards the default options to the search client', () => {
+    const addAlgoliaAgent = jest.fn();
+    algoliasearch.mockImplementation(() => {
+      return {
+        addAlgoliaAgent,
+      };
+    });
+
+    const ssrSearchClient = createSSRSearchClient({
+      appId: 'appId',
+      apiKey: 'apiKey',
+      httpClient: null,
+      HttpHeaders: null,
+      makeStateKey: null,
+      transferState: null,
+    });
+
+    expect(ssrSearchClient).toHaveBeenCalledWith('appId', 'apiKey', {});
+  });
+
+  it('forwards the options to the search client', () => {
+    const addAlgoliaAgent = jest.fn();
+    algoliasearch.mockImplementation(() => {
+      return {
+        addAlgoliaAgent,
+      };
+    });
+
+    const ssrSearchClient = createSSRSearchClient({
+      appId: 'appId',
+      apiKey: 'apiKey',
+      options: {
+        queryParameters: {},
+      },
+      httpClient: null,
+      HttpHeaders: null,
+      makeStateKey: null,
+      transferState: null,
+    });
+
+    expect(ssrSearchClient).toHaveBeenCalledWith('appId', 'apiKey', {
+      queryParameters: {},
+    });
+  });
 });

--- a/src/__tests__/create-ssr-search-client.spec.ts
+++ b/src/__tests__/create-ssr-search-client.spec.ts
@@ -53,7 +53,7 @@ describe('createSSRSearchClient', () => {
       transferState: null,
     });
 
-    expect(ssrSearchClient).toHaveBeenCalledWith('appId', 'apiKey', {});
+    expect(addAlgoliaAgent).toHaveBeenCalledWith('appId', 'apiKey', {});
   });
 
   it('forwards the options to the search client', () => {
@@ -76,7 +76,7 @@ describe('createSSRSearchClient', () => {
       transferState: null,
     });
 
-    expect(ssrSearchClient).toHaveBeenCalledWith('appId', 'apiKey', {
+    expect(addAlgoliaAgent).toHaveBeenCalledWith('appId', 'apiKey', {
       queryParameters: {},
     });
   });

--- a/src/__tests__/create-ssr-search-client.spec.ts
+++ b/src/__tests__/create-ssr-search-client.spec.ts
@@ -53,7 +53,7 @@ describe('createSSRSearchClient', () => {
       transferState: null,
     });
 
-    expect(addAlgoliaAgent).toHaveBeenCalledWith('appId', 'apiKey', {});
+    expect(algoliasearch).toHaveBeenCalledWith('appId', 'apiKey', {});
   });
 
   it('forwards the options to the search client', () => {
@@ -76,7 +76,7 @@ describe('createSSRSearchClient', () => {
       transferState: null,
     });
 
-    expect(addAlgoliaAgent).toHaveBeenCalledWith('appId', 'apiKey', {
+    expect(algoliasearch).toHaveBeenCalledWith('appId', 'apiKey', {
       queryParameters: {},
     });
   });

--- a/src/create-ssr-search-client.ts
+++ b/src/create-ssr-search-client.ts
@@ -11,6 +11,7 @@ type SSRSearchClientOptions = {
   httpClient: HttpClient;
   HttpHeaders: typeof HttpHeaders;
   transferState: TransferState;
+  options?: object;
   makeStateKey<T = void>(key: string): StateKey<T>;
 };
 
@@ -32,8 +33,9 @@ export function createSSRSearchClient({
   HttpHeaders,
   transferState,
   makeStateKey,
+  options = {},
 }: SSRSearchClientOptions) {
-  const searchClient = algoliasearch(appId, apiKey);
+  const searchClient = algoliasearch(appId, apiKey, options);
 
   searchClient.addAlgoliaAgent(`angular (${AngularVersion.full})`);
   searchClient.addAlgoliaAgent(`angular-instantsearch (${VERSION})`);


### PR DESCRIPTION
This would be needed for us to put a proxy between Algolia and our frontend to track impressions more effectively on the backend.

**Summary**
I want to set up `hosts.read` and `hosts.write` to setup my proxy host, which will track product ids returned for a set of filters and etc.

Additionally, we will use more than one Algolia cluster so my `proxy` would balance between them without client modifications.

Same as #714

**Result**
