### PR TITLE
chore: update release script name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,4 +64,4 @@ jobs:
 
       - run:
           name: Trigger a release if the latest commit is a release commit
-          command: yarn release:trigger
+          command: yarn shipjs trigger

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Tests are ran with [jest](https://facebook.github.io/jest/) and [jest-preset-ang
 To release a stable version, go on master (`git checkout master`) and use:
 
 ```sh
-yarn run release:prepare
+yarn run release
 ```
 
 It will create a pull request for the next release. When it's reviewed, approved and merged, then CircleCI will automatically publish it to npm.

--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "doc:dev": "cd community-website && yarn && yarn start",
     "doc:build": "cd community-website && yarn && yarn docs:build",
     "doc:publish": "./scripts/publish-docs.sh",
-    "release:prepare": "shipjs prepare",
-    "release:trigger": "shipjs trigger"
+    "release": "shipjs prepare"
   },
   "jest": {
     "preset": "jest-preset-angular",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

This PR simplifies the command we run to prepare a release.

- Before: `yarn run release:prepare`
- After: `yarn run release`

On CircleCI, it used to run `yarn run release:trigger`, but now it runs `yarn shipjs trigger`.

related to: https://github.com/algolia/instantsearch.js/pull/4419