### PR TITLE
feat(widgets): introduce `ConfigureRelatedItems` as experimental

### DIFF
--- a/examples/storybook/.storybook/styles.css
+++ b/examples/storybook/.storybook/styles.css
@@ -121,3 +121,52 @@ button:not([class^='ais-']) {
 button:not([class^='ais-']):disabled {
   border-color: #c4c8d8;
 }
+
+/* Related Items */
+
+.related-items {
+  display: flex;
+  align-items: center;
+}
+
+.related-items .ais-Hits-list {
+  margin-left: 0;
+  margin-right: 1rem;
+}
+
+.ais-RelatedHits-item-image {
+  height: 150px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  background-color: #fff;
+}
+
+.ais-RelatedHits-item-image img {
+  max-height: 120px;
+  max-width: 100%;
+}
+
+.ais-RelatedHits-item-title {
+  text-align: center;
+  padding: 1rem;
+}
+
+.ais-RelatedHits-item-title h4 {
+  margin: 0;
+}
+
+.ais-RelatedHits-button {
+  height: 40px;
+  width: 40px;
+  border-radius: 3px;
+  background-color: #dfe2ee;
+  border: none;
+  color: #3a4570;
+  cursor: pointer;
+}
+
+.ais-RelatedHits-button[disabled] {
+  cursor: not-allowed;
+}

--- a/examples/storybook/src/stories/ConfigureRelatedItems.stories.ts
+++ b/examples/storybook/src/stories/ConfigureRelatedItems.stories.ts
@@ -9,25 +9,23 @@ storiesOf('ConfigureRelatedItems', module)
       component: wrapWithHits({
         template: `
         <div>
-          <ais-index indexName="instant_search">
-            <ais-configure [searchParameters]="{ hitsPerPage: 1 }"></ais-configure>
-            <ais-hits>
-              <ng-template let-hits="hits">
-                <div *ngFor="let hit of hits">
-                  <div class="ais-RelatedHits-item-image">
-                    <img [src]="hit.image" [alt]="hit.name" />
-                  </div>
-
-                  <div class="ais-RelatedHits-item-title">
-                    <h4>{{hit.name}}</h4>
-                  </div>
+          <ais-configure [searchParameters]="{ hitsPerPage: 1 }"></ais-configure>
+          <ais-hits>
+            <ng-template let-hits="hits">
+              <div *ngFor="let hit of hits">
+                <p>objectID: <code>{{hit.objectID}}</code></p>
+                <div class="ais-RelatedHits-item-image">
+                  <img [src]="hit.image" [alt]="hit.name" />
                 </div>
-              </ng-template>
-            </ais-hits>
-          </ais-index>
+                <div class="ais-RelatedHits-item-title">
+                  <h4>{{hit.name}}</h4>
+                </div>
+              </div>
+            </ng-template>
+          </ais-hits>
 
-          <ais-index indexName="instant_search">
-            <h2>Related items</h2>
+          <ais-index indexName="instant_search" indexId="related">
+            <h2>Related items to <code>{{hit.objectID}}</code></h2>
 
             <ais-configure [searchParameters]="{ hitsPerPage: 4 }"></ais-configure>
             <ais-experimental-configure-related-items

--- a/examples/storybook/src/stories/ConfigureRelatedItems.stories.ts
+++ b/examples/storybook/src/stories/ConfigureRelatedItems.stories.ts
@@ -1,0 +1,86 @@
+import { storiesOf } from '@storybook/angular';
+import { wrapWithHits } from '../wrap-with-hits';
+import meta from '../meta';
+
+storiesOf('ConfigureRelatedItems', module)
+  .addDecorator(meta)
+  .add('default', () => {
+    return {
+      component: wrapWithHits({
+        template: `
+        <div>
+          <ais-index indexName="instant_search">
+            <ais-configure [searchParameters]="{ hitsPerPage: 1 }"></ais-configure>
+            <ais-hits>
+              <ng-template let-hits="hits">
+                <div *ngFor="let hit of hits">
+                  <div class="ais-RelatedHits-item-image">
+                    <img [src]="hit.image" [alt]="hit.name" />
+                  </div>
+
+                  <div class="ais-RelatedHits-item-title">
+                    <h4>{{hit.name}}</h4>
+                  </div>
+                </div>
+              </ng-template>
+            </ais-hits>
+          </ais-index>
+
+          <ais-index indexName="instant_search">
+            <h2>Related items</h2>
+
+            <ais-configure [searchParameters]="{ hitsPerPage: 4 }"></ais-configure>
+            <ais-experimental-configure-related-items
+              [hit]="hit"
+              [matchingPatterns]="matchingPatterns"
+            ></ais-experimental-configure-related-items>
+
+            <div class="related-items">
+              <ais-hits>
+                <ng-template let-hits="hits">
+                  <div class="ais-Hits-list">
+                    <div *ngFor="let hit of hits" class="ais-Hits-item">
+                      <div class="ais-RelatedHits-item-image">
+                        <img [src]="hit.image" [alt]="hit.name" />
+                      </div>
+
+                      <div class="ais-RelatedHits-item-title">
+                        <h4>{{hit.name}}</h4>
+                      </div>
+                    </div>
+                  </div>
+                </ng-template>
+              </ais-hits>
+            </div>
+          </ais-index>
+        </div>
+      `,
+        methods: {
+          hit: {
+            objectID: '5477500',
+            name: 'Amazon - Fire TV Stick with Alexa Voice Remote - Black',
+            description:
+              'Enjoy smart access to videos, games and apps with this Amazon Fire TV stick. Its Alexa voice remote lets you deliver hands-free commands when you want to watch television or engage with other applications. With a quad-core processor, 1GB internal memory and 8GB of storage, this portable Amazon Fire TV stick works fast for buffer-free streaming.',
+            brand: 'Amazon',
+            categories: ['TV & Home Theater', 'Streaming Media Players'],
+            hierarchicalCategories: {
+              lvl0: 'TV & Home Theater',
+              lvl1: 'TV & Home Theater > Streaming Media Players',
+            },
+            type: 'Streaming media plyr',
+            price: 39.99,
+            price_range: '1 - 50',
+            image: 'https://cdn-demo.algolia.com/bestbuy-0118/5477500_sb.jpg',
+            url: 'https://api.bestbuy.com/click/-/5477500/pdp',
+            free_shipping: false,
+            rating: 4,
+          },
+          matchingPatterns: {
+            brand: { score: 3 },
+            type: { score: 10 },
+            categories: { score: 2 },
+          },
+        },
+      }),
+    };
+  });

--- a/src/configure-related-items/__tests__/__snapshots__/configure-related-items.spec.ts.snap
+++ b/src/configure-related-items/__tests__/__snapshots__/configure-related-items.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfigureRelatedItems renders markup 1`] = `
+<ng-component
+  testedWidget={[Function NgAisConfigureRelatedItems]}
+>
+  <ais-instantsearch>
+    <ais-experimental-configure-related-items />
+  </ais-instantsearch>
+</ng-component>
+`;

--- a/src/configure-related-items/__tests__/configure-related-items.spec.ts
+++ b/src/configure-related-items/__tests__/configure-related-items.spec.ts
@@ -25,9 +25,13 @@ describe('ConfigureRelatedItems', () => {
 
     const render = createRenderer({
       TestedWidget: NgAisConfigureRelatedItems,
-      template:
-        '<ais-experimental-configure-related-items></ais-experimental-configure-related-items>',
-      defaultState: {
+      template: `
+      <ais-experimental-configure-related-items
+        [hit]="hit"
+        [matchingPatterns]="matchingPatterns"
+        [transformSearchParameters]="transformSearchParameters"
+      ></ais-experimental-configure-related-items>`,
+      methods: {
         hit,
         matchingPatterns,
         transformSearchParameters,

--- a/src/configure-related-items/__tests__/configure-related-items.spec.ts
+++ b/src/configure-related-items/__tests__/configure-related-items.spec.ts
@@ -1,0 +1,45 @@
+import { createRenderer } from '../../../helpers/test-renderer';
+import { NgAisConfigureRelatedItems } from '../configure-related-items';
+
+describe('ConfigureRelatedItems', () => {
+  it('renders markup', () => {
+    const render = createRenderer({
+      TestedWidget: NgAisConfigureRelatedItems,
+      template:
+        '<ais-experimental-configure-related-items></ais-experimental-configure-related-items>',
+    });
+
+    const fixture = render();
+
+    expect(fixture).toMatchSnapshot();
+  });
+
+  it('forwards options', () => {
+    const createWidget = jest.spyOn(
+      NgAisConfigureRelatedItems.prototype,
+      'createWidget'
+    );
+    const hit = {};
+    const matchingPatterns = {};
+    const transformSearchParameters = jest.fn();
+
+    const render = createRenderer({
+      TestedWidget: NgAisConfigureRelatedItems,
+      template:
+        '<ais-experimental-configure-related-items></ais-experimental-configure-related-items>',
+      defaultState: {
+        hit,
+        matchingPatterns,
+        transformSearchParameters,
+      },
+    });
+
+    render();
+
+    expect(createWidget.mock.calls[0][1]).toEqual({
+      hit,
+      matchingPatterns,
+      transformSearchParameters,
+    });
+  });
+});

--- a/src/configure-related-items/configure-related-items.module.ts
+++ b/src/configure-related-items/configure-related-items.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { NgAisConfigureRelatedItems } from './configure-related-items';
+
+@NgModule({
+  declarations: [NgAisConfigureRelatedItems],
+  entryComponents: [NgAisConfigureRelatedItems],
+  exports: [NgAisConfigureRelatedItems],
+  imports: [CommonModule],
+})
+export class NgAisConfigureRelatedItemsModule {}

--- a/src/configure-related-items/configure-related-items.ts
+++ b/src/configure-related-items/configure-related-items.ts
@@ -1,20 +1,32 @@
-import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
+import {
+  Component,
+  Input,
+  Inject,
+  forwardRef,
+  Optional,
+  KeyValueDiffer,
+  KeyValueDiffers,
+} from '@angular/core';
 
 import { EXPERIMENTAL_connectConfigureRelatedItems } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
+import { AlgoliaHit } from 'instantsearch.js';
 
 @Component({
   selector: 'ais-experimental-configure-related-items',
   template: '',
 })
 export class NgAisConfigureRelatedItems extends BaseWidget {
-  @Input() public hit: object;
+  private internalHit: AlgoliaHit;
+  private differ: KeyValueDiffer<string, any>;
+
   @Input() public matchingPatterns: object;
   @Input() public transformSearchParameters: Function;
 
   constructor(
+    private differs: KeyValueDiffers,
     @Inject(forwardRef(() => NgAisIndex))
     @Optional()
     public parentIndex: NgAisIndex,
@@ -24,13 +36,35 @@ export class NgAisConfigureRelatedItems extends BaseWidget {
     super('ExperimentalConfigureRelatedItems');
   }
 
+  @Input()
+  set hit(values: AlgoliaHit) {
+    this.internalHit = values;
+    if (!this.differ && values) {
+      this.differ = this.differs.find(values).create();
+    }
+  }
+
   public ngOnInit() {
     this.createWidget(EXPERIMENTAL_connectConfigureRelatedItems, {
-      hit: this.hit,
+      hit: this.internalHit,
       matchingPatterns: this.matchingPatterns,
       transformSearchParameters: this.transformSearchParameters,
     });
 
     super.ngOnInit();
+  }
+
+  ngDoCheck() {
+    if (this.differ) {
+      const changes = this.differ.diff(this.internalHit);
+      if (changes) {
+        this.parent.removeWidgets([this.widget]);
+        this.createWidget(EXPERIMENTAL_connectConfigureRelatedItems, {
+          hit: this.internalHit,
+          matchingPatterns: this.matchingPatterns,
+          transformSearchParameters: this.transformSearchParameters,
+        });
+      }
+    }
   }
 }

--- a/src/configure-related-items/configure-related-items.ts
+++ b/src/configure-related-items/configure-related-items.ts
@@ -17,9 +17,9 @@ export class NgAisConfigureRelatedItems extends BaseWidget {
   constructor(
     @Inject(forwardRef(() => NgAisIndex))
     @Optional()
-    public indexParent: NgAisIndex,
+    public parentIndex: NgAisIndex,
     @Inject(forwardRef(() => NgAisInstantSearch))
-    public instantSearchParent: NgAisInstantSearch
+    public instantSearchInstance: NgAisInstantSearch
   ) {
     super('ExperimentalConfigureRelatedItems');
   }

--- a/src/configure-related-items/configure-related-items.ts
+++ b/src/configure-related-items/configure-related-items.ts
@@ -1,32 +1,26 @@
-import {
-  Component,
-  Input,
-  Inject,
-  forwardRef,
-  Optional,
-  KeyValueDiffer,
-  KeyValueDiffers,
-} from '@angular/core';
+import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { EXPERIMENTAL_connectConfigureRelatedItems } from 'instantsearch.js/es/connectors';
 import { BaseWidget } from '../base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { AlgoliaHit } from 'instantsearch.js';
+import { ConfigureRelatedItemsConnectorParams } from 'instantsearch.js/es/connectors/configure-related-items/connectConfigureRelatedItems';
+
+type x = ConfigureRelatedItemsConnectorParams;
 
 @Component({
   selector: 'ais-experimental-configure-related-items',
   template: '',
 })
 export class NgAisConfigureRelatedItems extends BaseWidget {
-  private internalHit: AlgoliaHit;
-  private differ: KeyValueDiffer<string, any>;
-
-  @Input() public matchingPatterns: object;
-  @Input() public transformSearchParameters: Function;
+  @Input() hit: ConfigureRelatedItemsConnectorParams['hit'];
+  @Input()
+  public matchingPatterns: ConfigureRelatedItemsConnectorParams['matchingPatterns'];
+  @Input()
+  public transformSearchParameters: ConfigureRelatedItemsConnectorParams['transformSearchParameters'];
 
   constructor(
-    private differs: KeyValueDiffers,
     @Inject(forwardRef(() => NgAisIndex))
     @Optional()
     public parentIndex: NgAisIndex,
@@ -36,35 +30,13 @@ export class NgAisConfigureRelatedItems extends BaseWidget {
     super('ExperimentalConfigureRelatedItems');
   }
 
-  @Input()
-  set hit(values: AlgoliaHit) {
-    this.internalHit = values;
-    if (!this.differ && values) {
-      this.differ = this.differs.find(values).create();
-    }
-  }
-
   public ngOnInit() {
     this.createWidget(EXPERIMENTAL_connectConfigureRelatedItems, {
-      hit: this.internalHit,
+      hit: this.hit,
       matchingPatterns: this.matchingPatterns,
       transformSearchParameters: this.transformSearchParameters,
     });
 
     super.ngOnInit();
-  }
-
-  ngDoCheck() {
-    if (this.differ) {
-      const changes = this.differ.diff(this.internalHit);
-      if (changes) {
-        this.parent.removeWidgets([this.widget]);
-        this.createWidget(EXPERIMENTAL_connectConfigureRelatedItems, {
-          hit: this.internalHit,
-          matchingPatterns: this.matchingPatterns,
-          transformSearchParameters: this.transformSearchParameters,
-        });
-      }
-    }
   }
 }

--- a/src/configure-related-items/configure-related-items.ts
+++ b/src/configure-related-items/configure-related-items.ts
@@ -1,0 +1,36 @@
+import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
+
+import { EXPERIMENTAL_connectConfigureRelatedItems } from 'instantsearch.js/es/connectors';
+import { BaseWidget } from '../base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
+import { NgAisIndex } from '../index-widget/index-widget';
+
+@Component({
+  selector: 'ais-experimental-configure-related-items',
+  template: '',
+})
+export class NgAisConfigureRelatedItems extends BaseWidget {
+  @Input() public hit: object;
+  @Input() public matchingPatterns: object;
+  @Input() public transformSearchParameters: Function;
+
+  constructor(
+    @Inject(forwardRef(() => NgAisIndex))
+    @Optional()
+    public indexParent: NgAisIndex,
+    @Inject(forwardRef(() => NgAisInstantSearch))
+    public instantSearchParent: NgAisInstantSearch
+  ) {
+    super('ExperimentalConfigureRelatedItems');
+  }
+
+  public ngOnInit() {
+    this.createWidget(EXPERIMENTAL_connectConfigureRelatedItems, {
+      hit: this.hit,
+      matchingPatterns: this.matchingPatterns,
+      transformSearchParameters: this.transformSearchParameters,
+    });
+
+    super.ngOnInit();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ import { NgAisPanelModule } from './panel/panel.module';
 export { NgAisPanelModule };
 import { NgAisConfigureModule } from './configure/configure.module';
 export { NgAisConfigureModule };
+import { NgAisConfigureRelatedItemsModule } from './configure-related-items/configure-related-items.module';
+export { NgAisConfigureRelatedItemsModule };
 import { NgAisQueryRuleCustomDataModule } from './query-rule-custom-data/query-rule-custom-data.module';
 export { NgAisQueryRuleCustomDataModule };
 import { NgAisQueryRuleContextModule } from './query-rule-context/query-rule-context.module';
@@ -87,6 +89,7 @@ const NGIS_MODULES = [
   NgAisRangeInputModule,
   NgAisPanelModule,
   NgAisConfigureModule,
+  NgAisConfigureRelatedItemsModule,
   NgAisQueryRuleCustomDataModule,
   NgAisQueryRuleContextModule,
   NgAisVoiceSearchModule,


### PR DESCRIPTION
**Summary**

Not every UI for which Algolia can be used leans itself to a search interface, this widget is useful for a "related items" list, e.g. on a product page

**Result**

A new widget: `ais-configure-related-items`, to be used inside a separate `ais-index`, with a hit as target and `ais-hits` as its UI.