### PR TITLE
fix(createSSRSearchClient): handle headers object in options

### DIFF
--- a/src/__tests__/create-ssr-algolia-client.spec.ts
+++ b/src/__tests__/create-ssr-algolia-client.spec.ts
@@ -78,4 +78,33 @@ describe('Create SSR', () => {
       queryParameters: {},
     });
   });
+
+  it('forwards the options headers to the search client', () => {
+    const addAlgoliaAgent = jest.fn();
+    algoliasearchProxy.mockImplementation(() => {
+      return {
+        addAlgoliaAgent,
+      };
+    });
+
+    createSSRSearchClient({
+      appId: 'appId',
+      apiKey: 'apiKey',
+      options: {
+        headers: {
+          key: 'value',
+        },
+      },
+      httpClient: null,
+      HttpHeaders: null,
+      makeStateKey: null,
+      transferState: null,
+    });
+
+    expect(algoliasearchProxy).toHaveBeenCalledWith('appId', 'apiKey', {
+      headers: {
+        key: 'value',
+      },
+    });
+  });
 });

--- a/src/create-ssr-algolia-client.ts
+++ b/src/create-ssr-algolia-client.ts
@@ -9,13 +9,23 @@ import { VERSION } from './version';
 const algoliasearch = algoliasearchProxy.default || algoliasearchProxy;
 const encode = encodeProxy.default || encodeProxy;
 
+interface SSRAlogliaClientParams {
+  appId: string;
+  apiKey: string;
+  httpClient: any;
+  HttpHeaders: any;
+  makeStateKey: any;
+  transferState: any;
+  options?: any;
+}
+
 export function createSSRAlgoliaClient({
   httpClient,
   HttpHeaders,
   transferState,
   makeStateKey,
   options = {},
-}) {
+}: SSRAlogliaClientParams) {
   console.warn(
     '`createSSRAlgoliaClient` is deprecated in favor of `createSSRSearchClient` to be plugged to `searchClient`.'
   );
@@ -39,9 +49,9 @@ export function createSSRSearchClient({
   HttpHeaders,
   transferState,
   makeStateKey,
-  options = {},
-}) {
-  const client = algoliasearch(appId, apiKey, options);
+  options,
+}: SSRAlogliaClientParams) {
+  const client = algoliasearch(appId, apiKey, options || {});
   client.addAlgoliaAgent(`angular (${AngularVersion.full})`);
   client.addAlgoliaAgent(`angular-instantsearch (${VERSION})`);
   client.addAlgoliaAgent(`angular-instantsearch-server (${VERSION})`);
@@ -57,6 +67,12 @@ export function createSSRSearchClient({
     );
 
     headers = headers.set('accept', 'application/json');
+
+    if (options && options.headers) {
+      Object.keys(options.headers).map(key => {
+        headers = headers.set(key, options.headers[key]);
+      });
+    }
 
     const url =
       rawUrl + (rawUrl.includes('?') ? '&' : '?') + encode(opts.headers);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**
I was trying to add custom headers with `createSSRSearchClient` and I notice that was not handled. Because options was set to `{}`
So I added : 
- type for the param object
- set headers present in `options.header`

**Result**
Use like : 
```ts
createSSRSearchClient({
        appId: environment.algoliaAppId,
        apiKey: environment.algoliaApiKey,
        httpClient: this.httpClient,
        HttpHeaders,
        transferState: this.transferState,
        makeStateKey,
        options : { headers: { 'x-custom-header': 'value' } }
      })
```

The header will be added to the request. 