### PR TITLE
DO NOT MERGE: fix(types): add type inference to base-widget

### DIFF
--- a/src/base-widget.ts
+++ b/src/base-widget.ts
@@ -7,35 +7,20 @@ import {
   Widget,
   WidgetDescription,
   Connector,
+  Unmounter,
+  Renderer,
 } from 'instantsearch.js/es/types';
 
 export { Widget, Connector };
 
-export type ExtractConnectorParams<
-  T extends Connector<unknown & WidgetDescription, unknown>
-> = T extends Connector<infer TWidgetDescription, infer TConnectorParams>
-  ? TConnectorParams
-  : never;
-
-export type ExtractRenderer<
-  T extends Connector<unknown & WidgetDescription, unknown>
-> = Parameters<T>[0];
-
-export type ExtractUnmounter<
-  T extends Connector<unknown & WidgetDescription, unknown>
-> = Parameters<T>[1];
-
-export type ExtractRenderState<
-  T extends Connector<unknown & WidgetDescription, unknown>
-> = Parameters<ExtractRenderer<T>>[0];
-
 export abstract class BaseWidget<
-  TConnector extends Connector<unknown & WidgetDescription, unknown>
+  TWidgetDescription extends WidgetDescription,
+  TConnectorParams
 > implements OnInit, OnDestroy {
   @Input() public autoHideContainer?: boolean;
 
   public widget?: Widget;
-  public state?: ExtractRenderState<TConnector>;
+  public state?: TWidgetDescription['renderState'];
   public cx: ReturnType<typeof bem>;
   public abstract instantSearchInstance: NgAisInstantSearch;
   public abstract parentIndex?: NgAisIndex;
@@ -52,12 +37,10 @@ export abstract class BaseWidget<
   }
 
   public createWidget(
-    connector: TConnector,
-    options: ExtractConnectorParams<TConnector>
+    connector: Connector<TWidgetDescription, TConnectorParams>,
+    options: TConnectorParams
   ) {
-    this.widget = connector(this.updateState, noop as ExtractUnmounter<
-      TConnector
-    >)(options);
+    this.widget = connector(this.updateState, noop as Unmounter)(options);
   }
 
   public ngOnInit() {
@@ -70,10 +53,10 @@ export abstract class BaseWidget<
     }
   }
 
-  public updateState: ExtractRenderer<TConnector> = (
-    state,
-    isFirstRendering
-  ) => {
+  public updateState: Renderer<
+    TWidgetDescription['renderState'],
+    TConnectorParams
+  > = (state, isFirstRendering) => {
     if (isFirstRendering) {
       Promise.resolve().then(() => {
         this.state = state;


### PR DESCRIPTION
**Summary**

This change will allow type inference on the `state` and `updateState`.

For context:
- `updateState` is the name given to `renderFn` in InstantSearch.js
- `state` is simply the parameter passed to `renderFn` at each render. 

**Result**

This is helpful in templates

```ts
@Component({
  selector: 'app-rating-menu',
  template: `<div> {{state.createURL(1234)}} </div>`
                                     ^^^^
                                     // Argument type 1234 is not assignable to parameter type string
})
export class RatingMenu extends BaseWidget<typeof connectRatingMenu> {...}
```

This is also useful when customizing `updateState`

```ts
@Component({
  selector: 'app-rating-menu',
})
export class RatingMenu extends BaseWidget<typeof connectRatingMenu> {

	...
	public updateState(state /* type inferred */, isFirstRendering /* type inferred */) => {
		...
	}
}
```

This would be a BREAKING CHANGE but we can decide not make it one, if we
do this only on a TypedBaseWidget then migrate our widget there.

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->



<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->



<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
