### PR TITLE
fix(types): use InstantSearch.js types 

### DIFF
--- a/examples/media/package.json
+++ b/examples/media/package.json
@@ -34,6 +34,6 @@
     "codelyzer": "^5.1.2",
     "ts-node": "3.2.2",
     "tslint": "~6.1.0",
-    "typescript": "4.0.7"
+    "typescript": "4.3.5"
   }
 }

--- a/examples/media/yarn.lock
+++ b/examples/media/yarn.lock
@@ -1347,6 +1347,11 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
 
+"@types/qs@^6.5.3":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
 "@types/source-list-map@*":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
@@ -1642,10 +1647,10 @@ ajv@^6.10.2, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-algoliasearch-helper@^3.5.4:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.4.tgz#21b20ab8a258daa9dde9aef2daa5e8994cd66077"
-  integrity sha512-t+FLhXYnPZiwjYe5ExyN962HQY8mi3KwRju3Lyf6OBgtRdx30d6mqvtClXf5NeBihH45Xzj6t4Y5YyvAI432XA==
+algoliasearch-helper@^3.5.4, algoliasearch-helper@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz#05263869d3c8a7292278d7e49630f52520f204d7"
+  integrity sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==
   dependencies:
     events "^1.1.1"
 
@@ -1675,10 +1680,10 @@ alphanum-sort@^1.0.0:
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
 "angular-instantsearch@file:../../dist":
-  version "4.0.0-alpha.0"
+  version "4.0.0-alpha.2"
   dependencies:
     instantsearch.css "^7.3.1"
-    instantsearch.js "4.25.0-experimental-typescript.0"
+    instantsearch.js "4.26.0-experimental-typescript.0"
     nouislider "^10.0.0"
     querystring-es3 "^0.2.1"
     tslib "^2.1.0"
@@ -4664,6 +4669,21 @@ instantsearch.js@4.25.0-experimental-typescript.0:
     preact "^10.0.0"
     qs "^6.5.1"
 
+instantsearch.js@4.26.0-experimental-typescript.0:
+  version "4.26.0-experimental-typescript.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.26.0-experimental-typescript.0.tgz#ad130ffc26e52bbc53c8c49e3aac5597799a0fcc"
+  integrity sha512-ZiUZT5PgSpvLGQwBukIQbVn48a932o5WMZ5dvveBUURukKXxRMBKrsFZaXJ30aMugfgkQD93kK3KHT0siYP3PQ==
+  dependencies:
+    "@types/google.maps" "^3.45.3"
+    "@types/hogan.js" "^3.0.0"
+    "@types/qs" "^6.5.3"
+    algoliasearch-helper "^3.5.5"
+    classnames "^2.2.5"
+    events "^1.1.0"
+    hogan.js "^3.0.2"
+    preact "^10.0.0"
+    qs "^6.5.1 < 6.10"
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
@@ -6149,6 +6169,11 @@ object-inspect@^1.10.3:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
   integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
 
+object-inspect@^1.9.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
+  integrity sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==
+
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
@@ -7089,7 +7114,19 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.5.1, qs@~6.5.2:
+qs@^6.5.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
+
+"qs@^6.5.1 < 6.10":
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+
+qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
@@ -7820,6 +7857,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -8701,10 +8747,10 @@ typescript@4.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
   integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
-typescript@4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.7.tgz#7168032c43d2a2671c95c07812f69523c79590af"
-  integrity sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==
+typescript@4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"

--- a/examples/server-side-rendering/yarn.lock
+++ b/examples/server-side-rendering/yarn.lock
@@ -1568,6 +1568,11 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
   integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
+"@types/qs@^6.5.3":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
@@ -1873,6 +1878,13 @@ algoliasearch-helper@^3.5.4:
   dependencies:
     events "^1.1.1"
 
+algoliasearch-helper@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz#05263869d3c8a7292278d7e49630f52520f204d7"
+  integrity sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==
+  dependencies:
+    events "^1.1.1"
+
 algoliasearch@4.10.3:
   version "4.10.3"
   resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-4.10.3.tgz#22df4bb02fbf13a765b18b85df8745ee9c04f00a"
@@ -1899,10 +1911,10 @@ alphanum-sort@^1.0.2:
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
 "angular-instantsearch@file:../../dist":
-  version "4.0.0-alpha.0"
+  version "4.0.0-alpha.2"
   dependencies:
     instantsearch.css "^7.3.1"
-    instantsearch.js "4.25.0-experimental-typescript.0"
+    instantsearch.js "4.26.0-experimental-typescript.0"
     nouislider "^10.0.0"
     querystring-es3 "^0.2.1"
     tslib "^2.1.0"
@@ -4620,6 +4632,21 @@ instantsearch.js@4.25.0-experimental-typescript.0:
     preact "^10.0.0"
     qs "^6.5.1"
 
+instantsearch.js@4.26.0-experimental-typescript.0:
+  version "4.26.0-experimental-typescript.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.26.0-experimental-typescript.0.tgz#ad130ffc26e52bbc53c8c49e3aac5597799a0fcc"
+  integrity sha512-ZiUZT5PgSpvLGQwBukIQbVn48a932o5WMZ5dvveBUURukKXxRMBKrsFZaXJ30aMugfgkQD93kK3KHT0siYP3PQ==
+  dependencies:
+    "@types/google.maps" "^3.45.3"
+    "@types/hogan.js" "^3.0.0"
+    "@types/qs" "^6.5.3"
+    algoliasearch-helper "^3.5.5"
+    classnames "^2.2.5"
+    events "^1.1.0"
+    hogan.js "^3.0.2"
+    preact "^10.0.0"
+    qs "^6.5.1 < 6.10"
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"
@@ -7094,6 +7121,11 @@ qs@^6.5.1:
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
   dependencies:
     side-channel "^1.0.4"
+
+"qs@^6.5.1 < 6.10":
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
 qs@~6.5.2:
   version "6.5.2"

--- a/examples/storybook/src/stories/Breadcrumb.stories.ts
+++ b/examples/storybook/src/stories/Breadcrumb.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/angular';
 import { wrapWithHits } from '../wrap-with-hits';
 import meta from '../meta';
-import { BreadcrumbItem } from 'angular-instantsearch/breadcrumb/breadcrumb';
+import { BreadcrumbConnectorParamsItem } from 'instantsearch.js/es/connectors/breadcrumb/connectBreadcrumb';
 
 storiesOf('Breadcrumb', module)
   .addDecorator(meta)
@@ -29,7 +29,7 @@ storiesOf('Breadcrumb', module)
         },
       },
       methods: {
-        transformItems: (items: BreadcrumbItem[]) =>
+        transformItems: (items: BreadcrumbConnectorParamsItem[]) =>
           items.map(item => ({
             ...item,
             label: `${item.label} (transformed)`,

--- a/examples/storybook/src/stories/HierarchicalMenu.stories.ts
+++ b/examples/storybook/src/stories/HierarchicalMenu.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/angular';
 import { wrapWithHits } from '../wrap-with-hits';
 import meta from '../meta';
-import { HierarchicalMenuItem } from 'angular-instantsearch/hierarchical-menu/hierarchical-menu';
+import { HierarchicalMenuItem } from 'instantsearch.js/es/connectors/hierarchical-menu/connectHierarchicalMenu';
 
 storiesOf('HierarchicalMenu', module)
   .addDecorator(meta)

--- a/examples/storybook/src/stories/HitsPerPage.stories.ts
+++ b/examples/storybook/src/stories/HitsPerPage.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/angular';
 import { wrapWithHits } from '../wrap-with-hits';
 import meta from '../meta';
-import { HitsPerPageInstanceItem } from 'angular-instantsearch/hits-per-page/hits-per-page';
+import { HitsPerPageConnectorParamsItem } from 'instantsearch.js/es/connectors/hits-per-page/connectHitsPerPage';
 
 storiesOf('HitsPerPage', module)
   .addDecorator(meta)
@@ -34,7 +34,7 @@ storiesOf('HitsPerPage', module)
     }),
   }))
   .add('with transformItems', () => {
-    const transformItems = (items: HitsPerPageInstanceItem[]) =>
+    const transformItems = (items: HitsPerPageConnectorParamsItem[]) =>
       items.map(item => ({ ...item, label: `${item.label} (transformed)` }));
     return {
       component: wrapWithHits({

--- a/examples/storybook/src/stories/NumericMenu.stories.ts
+++ b/examples/storybook/src/stories/NumericMenu.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/angular';
 import { wrapWithHits } from '../wrap-with-hits';
 import meta from '../meta';
-import { NumericMenuItem } from 'angular-instantsearch/numeric-menu/numeric-menu';
+import { NumericMenuConnectorParamsItem } from 'instantsearch.js/es/connectors/numeric-menu/connectNumericMenu';
 
 storiesOf('NumericMenu', module)
   .addDecorator(meta)
@@ -25,7 +25,7 @@ storiesOf('NumericMenu', module)
     }),
   }))
   .add('with transformItems', () => {
-    const transformItems = (items: NumericMenuItem[]) => {
+    const transformItems = (items: NumericMenuConnectorParamsItem[]) => {
       return items.map(item => ({
         ...item,
         label: `${item.label} (transformed)`,

--- a/examples/storybook/src/stories/RefinementList.stories.ts
+++ b/examples/storybook/src/stories/RefinementList.stories.ts
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/angular';
 import { wrapWithHits } from '../wrap-with-hits';
 import meta from '../meta';
-import { RefinementListItem } from 'angular-instantsearch/refinement-list/refinement-list';
+import { RefinementListItem } from 'instantsearch.js/es/connectors/refinement-list/connectRefinementList';
 
 storiesOf('RefinementList', module)
   .addDecorator(meta)

--- a/helpers/test-renderer.ts
+++ b/helpers/test-renderer.ts
@@ -5,6 +5,7 @@ import { NgAisInstantSearchModule } from '../src/instantsearch/instantsearch.mod
 
 // mock component, don't create a real instantsearch instance
 jest.mock('../src/base-widget');
+jest.mock('../src/typed-base-widget');
 jest.mock('../src/instantsearch/instantsearch');
 
 export function createRenderer({

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "instantsearch.css": "^7.3.1",
     "nouislider": "^10.0.0",
     "querystring-es3": "^0.2.1",
-    "instantsearch.js": "4.25.0-experimental-typescript.0"
+    "instantsearch.js": "4.26.0-experimental-typescript.0"
   },
   "devDependencies": {
     "@angular/common": "12.0.3",

--- a/src/__mocks__/typed-base-widget.ts
+++ b/src/__mocks__/typed-base-widget.ts
@@ -1,0 +1,53 @@
+import { OnDestroy, OnInit } from '@angular/core';
+import { bem } from '../utils';
+import {
+  Widget,
+  Connector,
+  Renderer,
+  WidgetDescription,
+} from 'instantsearch.js/es/types';
+
+export class TypedBaseWidget<
+  TWidgetDescription extends WidgetDescription,
+  TConnectorParams
+> implements OnInit, OnDestroy {
+  public widget?: Widget;
+  public state?: object;
+  public cx?: Function;
+
+  constructor(widgetName: string) {
+    this.cx = bem(widgetName);
+  }
+
+  public createWidget(
+    connector: Connector<TWidgetDescription, TConnectorParams>,
+    options: TConnectorParams
+  ) {
+    // nothing to do, test env
+  }
+
+  public ngOnInit() {
+    // nothing to do, test env
+  }
+
+  public ngOnDestroy() {
+    // nothing to do, test env
+  }
+
+  public updateState: Renderer<
+    TWidgetDescription['renderState'],
+    TConnectorParams
+  > = (state, isFirstRendering) => {
+    this.state = state;
+  };
+
+  public getItemClass(item: { isRefined?: boolean }) {
+    let className = this.cx('item');
+
+    if (item.isRefined) {
+      className = `${className} ${this.cx('item', 'selected')}`;
+    }
+
+    return className;
+  }
+}

--- a/src/__tests__/tree-shaking/tree-shaking.spec.ts
+++ b/src/__tests__/tree-shaking/tree-shaking.spec.ts
@@ -10,6 +10,7 @@ import { join } from 'path';
 import glob from 'glob';
 
 jest.mock('../../../src/base-widget');
+jest.mock('../../../src/typed-base-widget');
 jest.mock('../../../src/instantsearch/instantsearch');
 
 function readFileGlob(globPath: string): Promise<string> {

--- a/src/breadcrumb/breadcrumb.ts
+++ b/src/breadcrumb/breadcrumb.ts
@@ -1,20 +1,15 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 import { connectBreadcrumb } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import {
+  BreadcrumbConnectorParams,
+  BreadcrumbWidgetDescription,
+  BreadcrumbRenderState,
+  BreadcrumbConnectorParamsItem,
+} from 'instantsearch.js/es/connectors/breadcrumb/connectBreadcrumb';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type BreadcrumbState = {
-  createURL: (value: string) => string;
-  items: BreadcrumbItem[];
-  refine: (value: string) => void;
-};
-
-export type BreadcrumbItem = {
-  label: string;
-  value: string;
-};
 
 @Component({
   selector: 'ais-breadcrumb',
@@ -53,15 +48,15 @@ export type BreadcrumbItem = {
     </div>
   `,
 })
-export class NgAisBreadcrumb extends BaseWidget {
+export class NgAisBreadcrumb extends TypedBaseWidget<
+  BreadcrumbWidgetDescription,
+  BreadcrumbConnectorParams
+> {
   // instance options
-  @Input() public attributes: string[];
-  @Input() public rootPath?: string;
-  @Input() public separator?: string;
-  @Input()
-  public transformItems?: <U extends BreadcrumbItem>(
-    items: BreadcrumbItem[]
-  ) => U[];
+  @Input() public attributes: BreadcrumbConnectorParams['attributes'];
+  @Input() public rootPath?: BreadcrumbConnectorParams['rootPath'];
+  @Input() public separator?: BreadcrumbConnectorParams['separator'];
+  @Input() public transformItems?: BreadcrumbConnectorParams['transformItems'];
 
   get isHidden() {
     return this.state.items.length === 0 && this.autoHideContainer;
@@ -77,10 +72,11 @@ export class NgAisBreadcrumb extends BaseWidget {
     }));
   }
 
-  public state: BreadcrumbState = {
+  public state: BreadcrumbRenderState = {
     createURL: () => '#',
     items: [],
     refine: noop,
+    canRefine: false,
   };
 
   constructor(
@@ -104,7 +100,10 @@ export class NgAisBreadcrumb extends BaseWidget {
     super.ngOnInit();
   }
 
-  public handleClick(event: MouseEvent, item: BreadcrumbItem): void {
+  public handleClick(
+    event: MouseEvent,
+    item: BreadcrumbConnectorParamsItem
+  ): void {
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/clear-refinements/clear-refinements.ts
+++ b/src/clear-refinements/clear-refinements.ts
@@ -1,15 +1,14 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 import { connectClearRefinements } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import {
+  ClearRefinementsConnectorParams,
+  ClearRefinementsWidgetDescription,
+  ClearRefinementsRenderState,
+} from 'instantsearch.js/es/connectors/clear-refinements/connectClearRefinements';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-type ClearRefinementsState = {
-  hasRefinements: boolean;
-  refine: () => void;
-  createURL: () => string;
-};
 
 @Component({
   selector: 'ais-clear-refinements',
@@ -28,17 +27,24 @@ type ClearRefinementsState = {
     </div>
   `,
 })
-export class NgAisClearRefinements extends BaseWidget {
+export class NgAisClearRefinements extends TypedBaseWidget<
+  ClearRefinementsWidgetDescription,
+  ClearRefinementsConnectorParams
+> {
   // rendering options
   @Input() public resetLabel: string = 'Clear refinements';
 
   // instance options
-  @Input() public includedAttributes: string[];
-  @Input() public excludedAttributes: string[];
-  @Input() public transformItems?: (items: string[]) => string[];
+  @Input()
+  public includedAttributes: ClearRefinementsConnectorParams['includedAttributes'];
+  @Input()
+  public excludedAttributes: ClearRefinementsConnectorParams['excludedAttributes'];
+  @Input()
+  public transformItems?: ClearRefinementsConnectorParams['transformItems'];
 
-  public state: ClearRefinementsState = {
+  public state: ClearRefinementsRenderState = {
     hasRefinements: false,
+    canRefine: false,
     refine: noop,
     createURL: () => '#',
   };

--- a/src/configure-related-items/configure-related-items.ts
+++ b/src/configure-related-items/configure-related-items.ts
@@ -1,19 +1,22 @@
-import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
+import { Component, forwardRef, Inject, Input, Optional } from '@angular/core';
 
 import { EXPERIMENTAL_connectConfigureRelatedItems } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
-import { AlgoliaHit } from 'instantsearch.js';
-import { ConfigureRelatedItemsConnectorParams } from 'instantsearch.js/es/connectors/configure-related-items/connectConfigureRelatedItems';
-
-type x = ConfigureRelatedItemsConnectorParams;
+import {
+  ConfigureRelatedItemsConnectorParams,
+  ConfigureRelatedItemsWidgetDescription,
+} from 'instantsearch.js/es/connectors/configure-related-items/connectConfigureRelatedItems';
 
 @Component({
   selector: 'ais-experimental-configure-related-items',
   template: '',
 })
-export class NgAisConfigureRelatedItems extends BaseWidget {
+export class NgAisConfigureRelatedItems extends TypedBaseWidget<
+  ConfigureRelatedItemsWidgetDescription,
+  ConfigureRelatedItemsConnectorParams
+> {
   @Input() hit: ConfigureRelatedItemsConnectorParams['hit'];
   @Input()
   public matchingPatterns: ConfigureRelatedItemsConnectorParams['matchingPatterns'];

--- a/src/configure/configure.ts
+++ b/src/configure/configure.ts
@@ -9,29 +9,30 @@ import {
 } from '@angular/core';
 
 import { connectConfigure } from 'instantsearch.js/es/connectors';
-import { ConfigureConnectorParams } from 'instantsearch.js/es/connectors/configure/connectConfigure';
-import { BaseWidget } from '../base-widget';
+import {
+  ConfigureWidgetDescription,
+  ConfigureRenderState,
+  ConfigureConnectorParams,
+} from 'instantsearch.js/es/connectors/configure/connectConfigure';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type ConfigureState = {
-  refine: Function;
-};
-
-type SearchParameters = ConfigureConnectorParams['searchParameters'];
 
 @Component({
   selector: 'ais-configure',
   template: '',
 })
-export class NgAisConfigure extends BaseWidget {
+export class NgAisConfigure extends TypedBaseWidget<
+  ConfigureWidgetDescription,
+  ConfigureConnectorParams
+> {
   // instance options
-  private internalSearchParameters: SearchParameters;
+  private internalSearchParameters: ConfigureConnectorParams['searchParameters'];
 
-  private differ: KeyValueDiffer<string, any>; // SearchParameters (I don't know how to get the values of the type)
+  private differ: KeyValueDiffer<string, any>;
 
-  public state: ConfigureState = {
+  public state: ConfigureRenderState = {
     refine: noop,
   };
 
@@ -47,7 +48,7 @@ export class NgAisConfigure extends BaseWidget {
   }
 
   @Input()
-  set searchParameters(values: SearchParameters) {
+  set searchParameters(values: ConfigureConnectorParams['searchParameters']) {
     this.internalSearchParameters = values;
     if (!this.differ && values) {
       this.differ = this.differs.find(values).create();

--- a/src/current-refinements/current-refinements.ts
+++ b/src/current-refinements/current-refinements.ts
@@ -1,33 +1,16 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectCurrentRefinements } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import {
+  CurrentRefinementsConnectorParams,
+  CurrentRefinementsConnectorParamsRefinement,
+  CurrentRefinementsWidgetDescription,
+  CurrentRefinementsRenderState,
+} from 'instantsearch.js/es/connectors/current-refinements/connectCurrentRefinements';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type CurrentRefinementsItem = {
-  attribute: string;
-  label: string;
-  refine: Function;
-  refinements: {
-    type: string;
-    // TODO: create multiple types for each of the available refinement
-    // https://github.com/algolia/angular-instantsearch/pull/463#discussion_r255911232
-    attribute: string;
-    label: string;
-    value: string;
-    operator?: string;
-    exhaustive?: boolean;
-    count?: number;
-  }[];
-};
-
-export type CurrentRefinementsState = {
-  createURL: Function;
-  refine: Function;
-  items: CurrentRefinementsItem[];
-};
 
 @Component({
   selector: 'ais-current-refinements',
@@ -55,19 +38,23 @@ export type CurrentRefinementsState = {
     </div>
   `,
 })
-export class NgAisCurrentRefinements extends BaseWidget {
+export class NgAisCurrentRefinements extends TypedBaseWidget<
+  CurrentRefinementsWidgetDescription,
+  CurrentRefinementsConnectorParams
+> {
   // instance options
-  @Input() public includedAttributes?: string[];
-  @Input() public excludedAttributes?: string[];
   @Input()
-  public transformItems?: <U extends CurrentRefinementsItem>(
-    items: CurrentRefinementsItem[]
-  ) => U[];
+  public includedAttributes?: CurrentRefinementsConnectorParams['includedAttributes'];
+  @Input()
+  public excludedAttributes?: CurrentRefinementsConnectorParams['excludedAttributes'];
+  @Input()
+  public transformItems?: CurrentRefinementsConnectorParams['transformItems'];
 
-  public state: CurrentRefinementsState = {
-    createURL: noop,
+  public state: CurrentRefinementsRenderState = {
+    createURL: () => '#',
     refine: noop,
     items: [],
+    canRefine: false,
   };
 
   get isHidden() {
@@ -93,7 +80,10 @@ export class NgAisCurrentRefinements extends BaseWidget {
     super.ngOnInit();
   }
 
-  public handleClick(event: MouseEvent, refinement: {}) {
+  public handleClick(
+    event: MouseEvent,
+    refinement: CurrentRefinementsConnectorParamsRefinement
+  ) {
     event.preventDefault();
     this.state.refine(refinement);
   }

--- a/src/hierarchical-menu/hierarchical-menu-item.ts
+++ b/src/hierarchical-menu/hierarchical-menu-item.ts
@@ -1,9 +1,9 @@
 import { Component, Input } from '@angular/core';
 import { bem } from '../utils';
 import {
+  HierarchicalMenuRenderState,
   HierarchicalMenuItem,
-  HierarchicalMenuState,
-} from './hierarchical-menu';
+} from 'instantsearch.js/es/connectors/hierarchical-menu/connectHierarchicalMenu';
 
 @Component({
   selector: 'ais-hierarchical-menu-item',
@@ -39,8 +39,8 @@ import {
 })
 export class NgAisHierarchicalMenuItem {
   @Input() public lvl: number = 1;
-  @Input() public refine: HierarchicalMenuState['refine'];
-  @Input() public createURL: HierarchicalMenuState['createURL'];
+  @Input() public refine: HierarchicalMenuRenderState['refine'];
+  @Input() public createURL: HierarchicalMenuRenderState['createURL'];
   @Input() public item: HierarchicalMenuItem;
 
   public cx = bem('HierarchicalMenu');

--- a/src/hierarchical-menu/hierarchical-menu.ts
+++ b/src/hierarchical-menu/hierarchical-menu.ts
@@ -1,27 +1,15 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectHierarchicalMenu } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
 import {
-  NgAisInstantSearch,
-  FacetSortByStringOptions,
-} from '../instantsearch/instantsearch';
+  HierarchicalMenuConnectorParams,
+  HierarchicalMenuWidgetDescription,
+  HierarchicalMenuRenderState,
+} from 'instantsearch.js/es/connectors/hierarchical-menu/connectHierarchicalMenu';
+import { TypedBaseWidget } from '../typed-base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { parseNumberInput, noop } from '../utils';
-
-export type HierarchicalMenuState = {
-  createURL: (value: string) => string;
-  items: HierarchicalMenuItem[];
-  refine: (value: string) => void;
-};
-
-export type HierarchicalMenuItem = {
-  value: string;
-  label: string;
-  count: number;
-  isRefined: boolean;
-  data: HierarchicalMenuItem[] | null;
-};
 
 @Component({
   selector: 'ais-hierarchical-menu',
@@ -42,26 +30,30 @@ export type HierarchicalMenuItem = {
     </div>
   `,
 })
-export class NgAisHierarchicalMenu extends BaseWidget {
-  @Input() public attributes: string[];
-  @Input() public separator?: string;
-  @Input() public rootPath?: string;
-  @Input() public showParentLevel?: boolean;
-  @Input() public limit?: number | string;
+export class NgAisHierarchicalMenu extends TypedBaseWidget<
+  HierarchicalMenuWidgetDescription,
+  HierarchicalMenuConnectorParams
+> {
+  @Input() public attributes: HierarchicalMenuConnectorParams['attributes'];
+  @Input() public separator?: HierarchicalMenuConnectorParams['separator'];
+  @Input() public rootPath?: HierarchicalMenuConnectorParams['rootPath'];
   @Input()
-  public sortBy?:
-    | FacetSortByStringOptions[]
-    | ((a: HierarchicalMenuItem, b: HierarchicalMenuItem) => number);
+  public showParentLevel?: HierarchicalMenuConnectorParams['showParentLevel'];
+  @Input() public limit?: HierarchicalMenuConnectorParams['limit'];
+  @Input() public sortBy?: HierarchicalMenuConnectorParams['sortBy'];
 
   @Input()
-  public transformItems?: <U extends HierarchicalMenuItem>(
-    items: HierarchicalMenuItem[]
-  ) => U[];
+  public transformItems?: HierarchicalMenuConnectorParams['transformItems'];
 
-  public state: HierarchicalMenuState = {
+  public state: HierarchicalMenuRenderState = {
     createURL: () => '#',
     items: [],
     refine: noop,
+    canRefine: false,
+    isShowingMore: false,
+    toggleShowMore: noop,
+    canToggleShowMore: false,
+    sendEvent: noop,
   };
 
   get isHidden(): boolean {

--- a/src/hits-per-page/hits-per-page.ts
+++ b/src/hits-per-page/hits-per-page.ts
@@ -1,27 +1,15 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectHitsPerPage } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import {
+  HitsPerPageConnectorParams,
+  HitsPerPageWidgetDescription,
+  HitsPerPageRenderState,
+} from 'instantsearch.js/es/connectors/hits-per-page/connectHitsPerPage';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type HitsPerPageState = {
-  items: HitsPerPageRenderingItem[];
-  refine: (value: number) => void;
-};
-
-export type HitsPerPageInstanceItem = {
-  value: number;
-  label: string;
-  default?: boolean;
-};
-
-export type HitsPerPageRenderingItem = {
-  value: number;
-  label: string;
-  isRefined: boolean;
-};
 
 @Component({
   selector: 'ais-hits-per-page',
@@ -46,17 +34,17 @@ export type HitsPerPageRenderingItem = {
     </div>
   `,
 })
-export class NgAisHitsPerPage extends BaseWidget {
-  @Input() public items: HitsPerPageInstanceItem[];
-  @Input()
-  public transformItems?: <U extends HitsPerPageRenderingItem>(
-    items: HitsPerPageRenderingItem[]
-  ) => U[];
+export class NgAisHitsPerPage extends TypedBaseWidget<
+  HitsPerPageWidgetDescription,
+  HitsPerPageConnectorParams
+> {
+  @Input() public items: HitsPerPageConnectorParams['items'];
+  @Input() public transformItems?: HitsPerPageConnectorParams['transformItems'];
 
-  public state: HitsPerPageState = {
+  public state: HitsPerPageRenderState = {
     items: [],
     refine: noop,
-    // TODO: add hasNoResults and disable <select> when true
+    hasNoResults: true, // TODO: disable <select> when true
   };
 
   get isHidden(): boolean {

--- a/src/hits/hits.ts
+++ b/src/hits/hits.ts
@@ -9,14 +9,14 @@ import {
 } from '@angular/core';
 
 import { connectHitsWithInsights } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
-import { NgAisInstantSearch, Hit } from '../instantsearch/instantsearch';
+import {
+  HitsConnectorParams,
+  HitsWidgetDescription,
+  HitsRenderState,
+} from 'instantsearch.js/es/connectors/hits/connectHits';
+import { TypedBaseWidget } from '../typed-base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
-
-export type HitsState = {
-  hits: Hit[];
-  results: {};
-};
 
 @Component({
   selector: 'ais-hits',
@@ -39,16 +39,21 @@ export type HitsState = {
     </div>
   `,
 })
-export class NgAisHits extends BaseWidget {
+export class NgAisHits extends TypedBaseWidget<
+  HitsWidgetDescription,
+  HitsConnectorParams
+> {
   @ContentChild(TemplateRef, { static: false })
   public template?: TemplateRef<any>;
 
-  @Input() public escapeHTML?: boolean;
-  @Input() public transformItems?: <U extends Hit>(items: Hit[]) => U[];
+  @Input() public escapeHTML?: HitsConnectorParams['escapeHTML'];
+  @Input() public transformItems?: HitsConnectorParams['transformItems'];
 
-  public state: HitsState = {
+  public state: HitsRenderState = {
     hits: [],
-    results: {},
+    results: undefined,
+    bindEvent: undefined,
+    sendEvent: undefined,
   };
 
   constructor(
@@ -69,7 +74,7 @@ export class NgAisHits extends BaseWidget {
     super.ngOnInit();
   }
 
-  updateState = (state, isFirstRendering: boolean) => {
+  public updateState = (state: HitsRenderState, isFirstRendering: boolean) => {
     if (isFirstRendering) return;
     this.state = state;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export { createSSRSearchClient } from './create-ssr-search-client';
 
 // Custom widget with BaseWidget class
 export { BaseWidget, Widget, Connector } from './base-widget';
+export { TypedBaseWidget } from './typed-base-widget';
 
 export { NgAisInstantSearch } from './instantsearch/instantsearch';
 export { NgAisIndex } from './index-widget/index-widget';

--- a/src/infinite-hits/infinite-hits.ts
+++ b/src/infinite-hits/infinite-hits.ts
@@ -73,7 +73,6 @@ export class NgAisInfiniteHits extends TypedBaseWidget<
   @Input()
   public transformItems?: InfiniteHitsConnectorParams['transformItems'];
 
-  // @ts-ignore
   public state: InfiniteHitsRenderState = {
     hits: [],
     results: undefined,
@@ -82,7 +81,6 @@ export class NgAisInfiniteHits extends TypedBaseWidget<
     isLastPage: false,
     showMore: noop,
     showPrevious: noop,
-    insights: undefined,
     sendEvent: noop,
     bindEvent: () => '',
   };

--- a/src/infinite-hits/infinite-hits.ts
+++ b/src/infinite-hits/infinite-hits.ts
@@ -7,21 +7,16 @@ import {
   forwardRef,
   Optional,
 } from '@angular/core';
-
 import { connectInfiniteHitsWithInsights } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
-import { NgAisInstantSearch, Hit } from '../instantsearch/instantsearch';
+import {
+  InfiniteHitsConnectorParams,
+  InfiniteHitsWidgetDescription,
+  InfiniteHitsRenderState,
+} from 'instantsearch.js/es/connectors/infinite-hits/connectInfiniteHits';
+import { TypedBaseWidget } from '../typed-base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type InfiniteHitsState = {
-  hits: Hit[];
-  results: any;
-  isFirstPage: boolean;
-  isLastPage: boolean;
-  showMore: Function;
-  showPrevious: Function;
-};
 
 @Component({
   selector: 'ais-infinite-hits',
@@ -62,25 +57,34 @@ export type InfiniteHitsState = {
     </div>
   `,
 })
-export class NgAisInfiniteHits extends BaseWidget {
+export class NgAisInfiniteHits extends TypedBaseWidget<
+  InfiniteHitsWidgetDescription,
+  InfiniteHitsConnectorParams
+> {
   @ContentChild(TemplateRef, { static: false })
   public template?: any;
 
   // rendering options
-  @Input() public escapeHTML: boolean;
-  @Input() public showPrevious: boolean = false;
+  @Input() public escapeHTML: InfiniteHitsConnectorParams['escapeHTML'];
+  @Input()
+  public showPrevious: InfiniteHitsConnectorParams['showPrevious'] = false;
   @Input() public showPreviousLabel: string = 'Show previous results';
   @Input() public showMoreLabel: string = 'Show more results';
-  @Input() public transformItems?: <U extends Hit>(items: Hit[]) => U[];
+  @Input()
+  public transformItems?: InfiniteHitsConnectorParams['transformItems'];
 
-  // inner widget state returned from connector
-  public state: InfiniteHitsState = {
+  // @ts-ignore
+  public state: InfiniteHitsRenderState = {
     hits: [],
+    results: undefined,
+    currentPageHits: [],
     isFirstPage: false,
     isLastPage: false,
     showMore: noop,
     showPrevious: noop,
-    results: {},
+    insights: undefined,
+    sendEvent: noop,
+    bindEvent: () => '',
   };
 
   constructor(

--- a/src/instantsearch/__tests__/instantsearch.spec.ts
+++ b/src/instantsearch/__tests__/instantsearch.spec.ts
@@ -12,7 +12,7 @@ jest.mock('instantsearch.js/es', () => () => {
   };
 });
 
-jest.mock('../../../src/base-widget');
+jest.mock('../../../src/typed-base-widget');
 
 describe('InstantSearch', () => {
   it('should add user agent when the client is provided to the config', () => {

--- a/src/instantsearch/instantsearch.ts
+++ b/src/instantsearch/instantsearch.ts
@@ -14,7 +14,7 @@ import {
 import * as algoliasearchProxy from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js/es';
 
-import { Widget } from '../base-widget';
+import { Widget } from '../typed-base-widget';
 import { VERSION } from '../version';
 import { InstantSearchOptions, InstantSearch } from 'instantsearch.js/es/types';
 export { SearchClient, Hit } from 'instantsearch.js/es/types';

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -1,29 +1,16 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectMenu } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
-import {
-  NgAisInstantSearch,
-  FacetSortByStringOptions,
-} from '../instantsearch/instantsearch';
+import { TypedBaseWidget } from '../typed-base-widget';
+import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type MenuItem = {
-  value: string;
-  label: string;
-  count: number;
-  isRefined: boolean;
-};
-
-export type MenuState = {
-  items: MenuItem[];
-  refine: Function;
-  createURL: Function;
-  isShowingMore: boolean;
-  canToggleShowMore: boolean;
-  toggleShowMore: Function;
-};
+import {
+  MenuConnectorParams,
+  MenuWidgetDescription,
+  MenuRenderState,
+  MenuItem,
+} from 'instantsearch.js/es/connectors/menu/connectMenu';
 
 @Component({
   selector: 'ais-menu',
@@ -60,30 +47,31 @@ export type MenuState = {
     </div>
   `,
 })
-export class NgAisMenu extends BaseWidget {
+export class NgAisMenu extends TypedBaseWidget<
+  MenuWidgetDescription,
+  MenuConnectorParams
+> {
   // rendering options
   @Input() public showMoreLabel: string = 'Show more';
   @Input() public showLessLabel: string = 'Show less';
 
   // instance options
-  @Input() public attribute: string;
-  @Input() public showMore?: boolean;
-  @Input() public limit?: number;
-  @Input() public showMoreLimit?: number;
-  @Input()
-  public sortBy?:
-    | FacetSortByStringOptions[]
-    | ((a: MenuItem, b: MenuItem) => number);
-  @Input()
-  public transformItems?: <U extends MenuItem>(items: MenuItem[]) => U[];
+  @Input() public attribute: MenuConnectorParams['attribute'];
+  @Input() public showMore?: MenuConnectorParams['showMore'];
+  @Input() public limit?: MenuConnectorParams['limit'];
+  @Input() public showMoreLimit?: MenuConnectorParams['showMoreLimit'];
+  @Input() public sortBy?: MenuConnectorParams['sortBy'];
+  @Input() public transformItems?: MenuConnectorParams['transformItems'];
 
-  public state: MenuState = {
+  public state: MenuRenderState = {
     items: [],
     refine: noop,
-    createURL: noop,
+    createURL: () => '#',
+    canRefine: false,
     isShowingMore: false,
     canToggleShowMore: false,
     toggleShowMore: noop,
+    sendEvent: noop,
   };
 
   get isHidden() {
@@ -123,7 +111,7 @@ export class NgAisMenu extends BaseWidget {
     super.ngOnInit();
   }
 
-  handleClick(event: MouseEvent, value: string) {
+  handleClick(event: MouseEvent, value: MenuItem['value']) {
     event.preventDefault();
     event.stopPropagation();
 

--- a/src/numeric-menu/numeric-menu.ts
+++ b/src/numeric-menu/numeric-menu.ts
@@ -1,23 +1,15 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectNumericMenu } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type NumericMenuItem = {
-  label: string;
-  value: string;
-  isRefined: boolean;
-};
-
-export type NumericMenuState = {
-  createURL: Function;
-  items: NumericMenuItem[];
-  refine: Function;
-  hasNoResults?: boolean;
-};
+import {
+  NumericMenuConnectorParams,
+  NumericMenuWidgetDescription,
+  NumericMenuRenderState,
+} from 'instantsearch.js/es/connectors/numeric-menu/connectNumericMenu';
 
 @Component({
   selector: 'ais-numeric-menu',
@@ -46,18 +38,20 @@ export type NumericMenuState = {
     </div>
   `,
 })
-export class NgAisNumericMenu extends BaseWidget {
-  @Input() public attribute: string;
-  @Input() public items: { label: string; start?: number; end?: number }[];
-  @Input()
-  public transformItems?: <U extends NumericMenuItem>(
-    items: NumericMenuItem[]
-  ) => U[];
+export class NgAisNumericMenu extends TypedBaseWidget<
+  NumericMenuWidgetDescription,
+  NumericMenuConnectorParams
+> {
+  @Input() public attribute: NumericMenuConnectorParams['attribute'];
+  @Input() public items: NumericMenuConnectorParams['items'];
+  @Input() public transformItems?: NumericMenuConnectorParams['transformItems'];
 
-  public state: NumericMenuState = {
+  public state: NumericMenuRenderState = {
     items: [],
     refine: noop,
-    createURL: noop,
+    createURL: () => '#',
+    hasNoResults: true,
+    sendEvent: noop,
   };
 
   get isHidden() {
@@ -83,7 +77,7 @@ export class NgAisNumericMenu extends BaseWidget {
     super.ngOnInit();
   }
 
-  public refine(event: MouseEvent, item: { value: string }) {
+  public refine(event: Event, item: { value: string }) {
     event.preventDefault();
     event.stopPropagation();
     this.state.refine(item.value);

--- a/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
+++ b/src/pagination/__tests__/__snapshots__/pagination.spec.ts.snap
@@ -132,7 +132,7 @@ exports[`Pagination renders markup without state 1`] = `
           >
             <a
               class="ais-Pagination-link"
-              href="null"
+              href="#"
             >
                ‹‹ 
             </a>
@@ -143,7 +143,7 @@ exports[`Pagination renders markup without state 1`] = `
           >
             <a
               class="ais-Pagination-link"
-              href="null"
+              href="#"
             >
                ‹ 
             </a>
@@ -155,7 +155,7 @@ exports[`Pagination renders markup without state 1`] = `
           >
             <a
               class="ais-Pagination-link"
-              href="null"
+              href="#"
             >
                › 
             </a>
@@ -166,7 +166,7 @@ exports[`Pagination renders markup without state 1`] = `
           >
             <a
               class="ais-Pagination-link"
-              href="null"
+              href="#"
             >
                ›› 
             </a>

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -1,9 +1,16 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 import { connectPagination } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { parseNumberInput, noop, range } from '../utils';
+import {
+  PaginationConnectorParams,
+  PaginationWidgetDescription,
+  PaginationRenderState,
+} from 'instantsearch.js/es/connectors/pagination/connectPagination';
+
+export { PaginationConnectorParams, PaginationRenderState };
 
 @Component({
   selector: 'ais-pagination',
@@ -103,23 +110,31 @@ import { parseNumberInput, noop, range } from '../utils';
     </div>
   `,
 })
-export class NgAisPagination extends BaseWidget {
+export class NgAisPagination extends TypedBaseWidget<
+  PaginationWidgetDescription,
+  PaginationConnectorParams
+> {
   // rendering options
   @Input() public showFirst: boolean = true;
   @Input() public showLast: boolean = true;
   @Input() public showPrevious: boolean = true;
   @Input() public showNext: boolean = true;
-  @Input() public padding: number | string = 3;
 
   // instance options
-  @Input() public totalPages?: number | string;
+  @Input() public padding: PaginationConnectorParams['padding'] = 3;
+  @Input() public totalPages?: PaginationConnectorParams['totalPages'];
+  // TODO: check if this works, padding and totalPages are most likely strings when passed to the template
 
-  public state = {
-    createURL: noop,
+  public state: PaginationRenderState = {
+    createURL: () => '#',
     currentRefinement: 0,
     nbHits: 0,
     nbPages: 0,
     refine: noop,
+    pages: [],
+    canRefine: false,
+    isFirstPage: false,
+    isLastPage: false,
   };
 
   get pages() {
@@ -179,7 +194,7 @@ export class NgAisPagination extends BaseWidget {
 
   public ngOnInit() {
     this.createWidget(connectPagination, {
-      maxPages: parseNumberInput(this.totalPages),
+      totalPages: parseNumberInput(this.totalPages),
     });
     super.ngOnInit();
   }

--- a/src/query-rule-context/query-rule-context.ts
+++ b/src/query-rule-context/query-rule-context.ts
@@ -1,22 +1,25 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectQueryRules } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
-
-type FacetValue = string | number | boolean;
+import {
+  QueryRulesConnectorParams,
+  QueryRulesWidgetDescription,
+} from 'instantsearch.js/es/connectors/query-rules/connectQueryRules';
 
 @Component({
   selector: 'ais-query-rule-context',
   template: '',
 })
-export class NgAisQueryRuleContext extends BaseWidget {
+export class NgAisQueryRuleContext extends TypedBaseWidget<
+  QueryRulesWidgetDescription,
+  QueryRulesConnectorParams
+> {
+  @Input() public trackedFilters: QueryRulesConnectorParams['trackedFilters'];
   @Input()
-  public trackedFilters: {
-    [facetName: string]: (facetValues: FacetValue[]) => FacetValue[];
-  };
-  @Input() public transformRuleContexts?: (items: string[]) => string[];
+  public transformRuleContexts?: QueryRulesConnectorParams['transformRuleContexts'];
 
   constructor(
     @Inject(forwardRef(() => NgAisIndex))

--- a/src/query-rule-custom-data/query-rule-custom-data.ts
+++ b/src/query-rule-custom-data/query-rule-custom-data.ts
@@ -9,33 +9,41 @@ import {
 } from '@angular/core';
 
 import { connectQueryRules } from 'instantsearch.js/es/connectors';
+import {
+  QueryRulesConnectorParams,
+  QueryRulesWidgetDescription,
+  QueryRulesRenderState,
+} from 'instantsearch.js/es/connectors/query-rules/connectQueryRules';
 
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 
 @Component({
   selector: 'ais-query-rule-custom-data',
   template: `
-    <div [class]="cx()">
-      <ng-container *ngTemplateOutlet="template; context: templateContext">
+    <div [class]='cx()'>
+      <ng-container *ngTemplateOutlet='template; context: templateContext'>
       </ng-container>
 
-      <div *ngIf="!template">
-        <div *ngFor="let item of state.items">
+      <div *ngIf='!template'>
+        <div *ngFor='let item of state.items'>
           <pre>{{ item | json }}</pre>
         </div>
       </div>
     </div>
   `,
 })
-export class NgAisQueryRuleCustomData extends BaseWidget {
+export class NgAisQueryRuleCustomData extends TypedBaseWidget<
+  QueryRulesWidgetDescription,
+  QueryRulesConnectorParams
+> {
   @ContentChild(TemplateRef, { static: false })
   public template: any;
 
-  @Input() public transformItems?: (items: any[]) => any[];
+  @Input() public transformItems?: QueryRulesConnectorParams['transformItems'];
 
-  public state = {
+  public state: QueryRulesRenderState = {
     items: [],
   };
 

--- a/src/rating-menu/rating-menu.ts
+++ b/src/rating-menu/rating-menu.ts
@@ -1,25 +1,15 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectRatingMenu } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop, parseNumberInput } from '../utils';
-
-export type RatingMenuItem = {
-  count: number;
-  isRefined: boolean;
-  name: string;
-  value: string;
-  stars: boolean[];
-};
-
-export type RatingMenuState = {
-  createURL: Function;
-  hasNoResults: boolean;
-  items: RatingMenuItem[];
-  refine: Function;
-};
+import {
+  RatingMenuConnectorParams,
+  RatingMenuWidgetDescription,
+  RatingMenuRenderState,
+} from 'instantsearch.js/es/connectors/rating-menu/connectRatingMenu';
 
 @Component({
   selector: 'ais-rating-menu',
@@ -85,7 +75,10 @@ export type RatingMenuState = {
     </div>
   `,
 })
-export class NgAisRatingMenu extends BaseWidget {
+export class NgAisRatingMenu extends TypedBaseWidget<
+  RatingMenuWidgetDescription,
+  RatingMenuConnectorParams
+> {
   // rendering options
   @Input() public andUpLabel: string = '& Up';
 
@@ -93,11 +86,13 @@ export class NgAisRatingMenu extends BaseWidget {
   @Input() public attribute: string;
   @Input() public max?: number;
 
-  public state: RatingMenuState = {
-    createURL: noop,
+  public state: RatingMenuRenderState = {
+    createURL: () => '#',
     hasNoResults: false,
     items: [],
     refine: noop,
+    canRefine: false,
+    sendEvent: noop,
   };
 
   get isHidden() {

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -12,10 +12,15 @@ import {
 } from '@angular/core';
 
 import { connectSearchBox } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
+import {
+  SearchBoxConnectorParams,
+  SearchBoxWidgetDescription,
+  SearchBoxRenderState,
+} from 'instantsearch.js/es/connectors/search-box/connectSearchBox';
 
 @Component({
   selector: 'ais-search-box',
@@ -75,7 +80,9 @@ import { noop } from '../utils';
     </div>
   `,
 })
-export class NgAisSearchBox extends BaseWidget implements AfterViewInit {
+export class NgAisSearchBox
+  extends TypedBaseWidget<SearchBoxWidgetDescription, SearchBoxConnectorParams>
+  implements AfterViewInit {
   @ViewChild('searchBox', { static: false })
   searchBox: ElementRef;
   @Input() public placeholder: string = 'Search';
@@ -94,9 +101,11 @@ export class NgAisSearchBox extends BaseWidget implements AfterViewInit {
   @Output() focus = new EventEmitter();
   @Output() blur = new EventEmitter();
 
-  public state = {
+  public state: SearchBoxRenderState = {
     query: '',
     refine: noop,
+    clear: noop,
+    isSearchStalled: false,
   };
 
   constructor(
@@ -107,7 +116,7 @@ export class NgAisSearchBox extends BaseWidget implements AfterViewInit {
     public instantSearchInstance: NgAisInstantSearch
   ) {
     super('SearchBox');
-    this.createWidget(connectSearchBox);
+    this.createWidget(connectSearchBox, {});
   }
 
   public ngAfterViewInit() {

--- a/src/sort-by/sort-by.ts
+++ b/src/sort-by/sort-by.ts
@@ -1,21 +1,24 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectSortBy } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
+import {
+  SortByConnector,
+  SortByConnectorParams,
+  SortByWidgetDescription,
+  SortByRenderState,
+  SortByItem,
+} from 'instantsearch.js/es/connectors/sort-by/connectSortBy';
 
-export type SortByItem = {
-  value: string;
-  label: string;
-};
-
-export type SortByState = {
-  currentRefinement: string | null;
-  options: SortByItem[];
-  refine: Function;
-  // TODO: add hasNoResults: boolean;
+export {
+  SortByConnector,
+  SortByConnectorParams,
+  SortByWidgetDescription,
+  SortByRenderState,
+  SortByItem,
 };
 
 @Component({
@@ -38,16 +41,19 @@ export type SortByState = {
     </div>
   `,
 })
-export class NgAisSortBy extends BaseWidget {
+export class NgAisSortBy extends TypedBaseWidget<
+  SortByWidgetDescription,
+  SortByConnectorParams
+> {
   @Input() public items: SortByItem[];
   @Input()
   public transformItems?: <U extends SortByItem>(items: SortByItem[]) => U[];
 
-  public state: SortByState = {
+  public state: SortByRenderState = {
     currentRefinement: null,
     options: [],
     refine: noop,
-    // TODO: Add hasNoResults: null,
+    hasNoResults: false,
   };
 
   constructor(

--- a/src/stats/stats.ts
+++ b/src/stats/stats.ts
@@ -9,9 +9,14 @@ import {
 
 import { connectStats } from 'instantsearch.js/es/connectors';
 
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
+import {
+  StatsConnectorParams,
+  StatsWidgetDescription,
+  StatsRenderState,
+} from 'instantsearch.js/es/connectors/stats/connectStats';
 
 @Component({
   selector: 'ais-stats',
@@ -26,17 +31,20 @@ import { NgAisIndex } from '../index-widget/index-widget';
     </div>
   `,
 })
-export class NgAisStats extends BaseWidget {
+export class NgAisStats extends TypedBaseWidget<
+  StatsWidgetDescription,
+  StatsConnectorParams
+> {
   @ContentChild(TemplateRef, { static: false })
   public template: any;
 
-  public state = {
-    hitPerPage: 0,
+  public state: StatsRenderState = {
     nbHits: 0,
     nbPages: 0,
     page: 0,
     processingTimeMS: 0,
     query: '',
+    areHitsSorted: false,
   };
 
   get templateContext() {
@@ -51,6 +59,6 @@ export class NgAisStats extends BaseWidget {
     public instantSearchInstance: NgAisInstantSearch
   ) {
     super('Stats');
-    this.createWidget(connectStats);
+    this.createWidget(connectStats, {});
   }
 }

--- a/src/toggle/toggle.ts
+++ b/src/toggle/toggle.ts
@@ -1,40 +1,27 @@
 import { Component, Input, Inject, forwardRef, Optional } from '@angular/core';
 
 import { connectToggleRefinement } from 'instantsearch.js/es/connectors';
-import { BaseWidget } from '../base-widget';
+import { TypedBaseWidget } from '../typed-base-widget';
 import { NgAisInstantSearch } from '../instantsearch/instantsearch';
 import { NgAisIndex } from '../index-widget/index-widget';
 import { noop } from '../utils';
-
-export type ToggleState = {
-  createURL: Function;
-  refine: Function;
-  value: {
-    name?: string;
-    count?: number;
-    isRefined?: boolean;
-    onFacetValue?: {
-      isRefined: boolean;
-      count: number;
-    };
-    offFacetValue?: {
-      isRefined: boolean;
-      count: number;
-    };
-  };
-};
+import {
+  ToggleRefinementConnectorParams,
+  ToggleRefinementWidgetDescription,
+  ToggleRefinementRenderState,
+} from 'instantsearch.js/es/connectors/toggle-refinement/connectToggleRefinement';
 
 @Component({
   selector: 'ais-toggle',
   template: `
-    <div [class]="cx()">
+    <div [class]='cx()'>
       <label [class]="cx('label')">
         <input
           [class]="cx('checkbox')"
-          type="checkbox"
-          value="{{state.value.name}}"
-          [checked]="state.value.isRefined"
-          (change)="handleChange($event)"
+          type='checkbox'
+          value='{{state.value.name}}'
+          [checked]='state.value.isRefined'
+          (change)='handleChange($event)'
         />
 
         <span [class]="cx('labelText')">
@@ -46,19 +33,30 @@ export type ToggleState = {
     </div>
   `,
 })
-export class NgAisToggle extends BaseWidget {
+export class NgAisToggle extends TypedBaseWidget<
+  ToggleRefinementWidgetDescription,
+  ToggleRefinementConnectorParams
+> {
   // rendering options
   @Input() public label: string;
 
   // instance options
-  @Input() public attribute: string;
-  @Input() public on?: boolean | number | string;
-  @Input() public off?: boolean | number | string;
+  @Input() public attribute: ToggleRefinementConnectorParams['attribute'];
+  @Input() public on?: ToggleRefinementConnectorParams['on'];
+  @Input() public off?: ToggleRefinementConnectorParams['off'];
 
-  public state: ToggleState = {
-    createURL: noop,
+  public state: ToggleRefinementRenderState = {
+    canRefine: false,
+    sendEvent: undefined,
+    value: {
+      count: undefined,
+      isRefined: false,
+      name: '',
+      offFacetValue: undefined,
+      onFacetValue: undefined,
+    },
+    createURL: () => '#',
     refine: noop,
-    value: {},
   };
 
   constructor(
@@ -80,7 +78,7 @@ export class NgAisToggle extends BaseWidget {
     super.ngOnInit();
   }
 
-  public handleChange(event: MouseEvent) {
+  public handleChange(event: Event) {
     event.preventDefault();
     event.stopPropagation();
     this.state.refine(this.state.value);

--- a/src/typed-base-widget.ts
+++ b/src/typed-base-widget.ts
@@ -1,0 +1,99 @@
+import { Input, OnDestroy, OnInit, forwardRef } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { bem, noop } from './utils';
+import { NgAisInstantSearch } from './instantsearch/instantsearch';
+import { NgAisIndex } from './index-widget/index-widget';
+import {
+  Widget,
+  WidgetDescription,
+  Connector,
+} from 'instantsearch.js/es/types';
+
+export { Widget, Connector };
+
+export type ExtractConnectorParams<
+  T extends Connector<unknown & WidgetDescription, unknown>
+> = T extends Connector<infer TWidgetDescription, infer TConnectorParams>
+  ? TConnectorParams
+  : never;
+
+export type ExtractRenderer<
+  T extends Connector<unknown & WidgetDescription, unknown>
+> = Parameters<T>[0];
+
+export type ExtractUnmounter<
+  T extends Connector<unknown & WidgetDescription, unknown>
+> = Parameters<T>[1];
+
+export type ExtractRenderState<
+  T extends Connector<unknown & WidgetDescription, unknown>
+> = Parameters<ExtractRenderer<T>>[0];
+
+export abstract class TypedBaseWidget<
+  TConnector extends Connector<unknown & WidgetDescription, unknown>
+> implements OnInit, OnDestroy {
+  @Input() public autoHideContainer?: boolean;
+
+  public widget?: Widget;
+  public state?: ExtractRenderState<TConnector>;
+  public cx: ReturnType<typeof bem>;
+  public abstract instantSearchInstance: NgAisInstantSearch;
+  public abstract parentIndex?: NgAisIndex;
+
+  protected constructor(widgetName: string) {
+    this.cx = bem(widgetName);
+  }
+
+  get parent() {
+    if (this.parentIndex) {
+      return this.parentIndex;
+    }
+    return this.instantSearchInstance;
+  }
+
+  public createWidget(
+    connector: TConnector,
+    options: ExtractConnectorParams<TConnector>
+  ) {
+    this.widget = connector(this.updateState, noop as ExtractUnmounter<
+      TConnector
+    >)(options);
+  }
+
+  public ngOnInit() {
+    this.parent.addWidgets([this.widget]);
+  }
+
+  public ngOnDestroy() {
+    if (isPlatformBrowser(this.instantSearchInstance.platformId)) {
+      this.parent.removeWidgets([this.widget]);
+    }
+  }
+
+  public updateState: ExtractRenderer<TConnector> = (
+    state,
+    isFirstRendering
+  ) => {
+    if (isFirstRendering) {
+      Promise.resolve().then(() => {
+        this.state = state;
+      });
+    } else {
+      this.state = state;
+    }
+  };
+
+  /**
+   * Helper to generate class names for an item
+   * @param item element to generate a class name for
+   */
+  public getItemClass(item: { isRefined?: boolean }): string {
+    const className = this.cx('item');
+
+    if (item.isRefined) {
+      return `${className} ${this.cx('item', 'selected')}`;
+    }
+
+    return className;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,6 +1316,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.2.tgz#5bb52ee68d0f8efa9cc0099920e56be6cc4e37f3"
   integrity sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
 
+"@types/qs@^6.5.3":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
@@ -1490,6 +1495,13 @@ algoliasearch-helper@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.4.tgz#21b20ab8a258daa9dde9aef2daa5e8994cd66077"
   integrity sha512-t+FLhXYnPZiwjYe5ExyN962HQY8mi3KwRju3Lyf6OBgtRdx30d6mqvtClXf5NeBihH45Xzj6t4Y5YyvAI432XA==
+  dependencies:
+    events "^1.1.1"
+
+algoliasearch-helper@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.5.5.tgz#05263869d3c8a7292278d7e49630f52520f204d7"
+  integrity sha512-JDH14gMpSj8UzEaKwVkrqKOeAOyK0dDWsFlKvWhk0Xl5yw9FyafYf1xZPb4uSXaPBAFQtUouFlR1Zt68BCY0/w==
   dependencies:
     events "^1.1.1"
 
@@ -5494,19 +5506,20 @@ instantsearch.css@^7.3.1:
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.3.1.tgz#7ab74a8f355091ae040947a9cf5438f379026622"
   integrity sha512-/kaMDna5D+Q9mImNBHEhb9HgHATDOFKYii7N1Iwvrj+lmD9gBJLqVhUw67gftq2O0QI330pFza+CRscIwB1wQQ==
 
-instantsearch.js@4.25.0-experimental-typescript.0:
-  version "4.25.0-experimental-typescript.0"
-  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.25.0-experimental-typescript.0.tgz#26ecd819a4fc2b8f15ebd02a6850331510b691f4"
-  integrity sha512-pi0LOaRQE80sq3JMA7MVEWcsbxFKLIqjsVaDEv6mF9z22VeV1yswFn1t7su30SnYjMzdWOtdS0kkJGZSyRGnCA==
+instantsearch.js@4.26.0-experimental-typescript.0:
+  version "4.26.0-experimental-typescript.0"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.26.0-experimental-typescript.0.tgz#ad130ffc26e52bbc53c8c49e3aac5597799a0fcc"
+  integrity sha512-ZiUZT5PgSpvLGQwBukIQbVn48a932o5WMZ5dvveBUURukKXxRMBKrsFZaXJ30aMugfgkQD93kK3KHT0siYP3PQ==
   dependencies:
     "@types/google.maps" "^3.45.3"
     "@types/hogan.js" "^3.0.0"
-    algoliasearch-helper "^3.5.4"
+    "@types/qs" "^6.5.3"
+    algoliasearch-helper "^3.5.5"
     classnames "^2.2.5"
     events "^1.1.0"
     hogan.js "^3.0.2"
     preact "^10.0.0"
-    qs "^6.5.1"
+    qs "^6.5.1 < 6.10"
 
 interpret@^1.0.0:
   version "1.2.0"
@@ -8745,10 +8758,10 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@^6.5.1:
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
-  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
+"qs@^6.5.1 < 6.10":
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
 qs@~6.5.2:
   version "6.5.2"


### PR DESCRIPTION
Changes of this PR.

#### 1. Introduces `TypedBaseWidget`, without removing `BaseWidget`

We could have replaced `BaseWidget` but that would:
- break many of the current implementations
- require to update the docs before the release.
- require update of all our doc-code-samples
I'm choosing to keep  `BaseWidget` and only deprecate it.


#### 2. Migrate all widgets to TypeBaseWidget and InstantSearch.js types.
  
We no longer expose types from the Angular Instantsearch themselves (users will need to get them from instantsearch.js)


#### 3. updates IS.js to 4.26 to use the latest types.


#### 4. Migrate storybook

