### PR TITLE
feat(dependencies): allow Angular 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,9 +151,9 @@
     "zone.js": "0.11.4"
   },
   "peerDependencies": {
-    "@angular/common": ">=5.0.0 <13.0.0",
-    "@angular/core": ">=5.0.0 <13.0.0",
-    "@angular/platform-browser": ">=5.0.0 <13.0.0",
-    "@angular/platform-browser-dynamic": ">=5.0.0 <13.0.0"
+    "@angular/common": ">=5.0.0 <14.0.0",
+    "@angular/core": ">=5.0.0 <14.0.0",
+    "@angular/platform-browser": ">=5.0.0 <14.0.0",
+    "@angular/platform-browser-dynamic": ">=5.0.0 <14.0.0"
   }
 }


### PR DESCRIPTION
There seem to be no required changes for Angular 13 to build, as you can see in https://github.com/Haroenv/angular-instantsearch-angular-13

I did not update the build dependencies to Angular 13, as it required some more changes that we can do later, the current version is usable as-is in angular 5 (possibly only from 8) - 14

fixes #885