### PR TITLE
fix(widgets): remove private access modifier on widgets inputs

### DIFF
--- a/src/reverse-highlight/reverse-highlight.ts
+++ b/src/reverse-highlight/reverse-highlight.ts
@@ -9,9 +9,9 @@ import { reverseHighlight } from 'instantsearch.js/es/helpers';
   template: `<span class="ais-ReverseHighlight" [innerHtml]="content"></span>`,
 })
 export class NgAisReverseHighlight {
-  @Input() private readonly attribute: string;
-  @Input() private readonly hit: Partial<Hit>;
-  @Input() private readonly highlightedTagName: string = 'mark';
+  @Input() attribute: string;
+  @Input() hit: Partial<Hit>;
+  @Input() highlightedTagName: string = 'mark';
 
   get content() {
     return reverseHighlight({

--- a/src/reverse-snippet/reverse-snippet.ts
+++ b/src/reverse-snippet/reverse-snippet.ts
@@ -9,9 +9,9 @@ import { reverseSnippet } from 'instantsearch.js/es/helpers';
   template: `<span class="ais-ReverseSnippet" [innerHtml]="content"></span>`,
 })
 export class NgAisReverseSnippet {
-  @Input() private readonly attribute: string;
-  @Input() private readonly hit: Partial<Hit>;
-  @Input() private readonly highlightedTagName: string = 'mark';
+  @Input() attribute: string;
+  @Input() hit: Partial<Hit>;
+  @Input() highlightedTagName: string = 'mark';
 
   get content() {
     return reverseSnippet({

--- a/src/snippet/snippet.ts
+++ b/src/snippet/snippet.ts
@@ -9,9 +9,9 @@ import { snippet } from 'instantsearch.js/es/helpers';
   template: `<span class="ais-Snippet" [innerHtml]="content"></span>`,
 })
 export class NgAisSnippet {
-  @Input() private readonly attribute: string;
-  @Input() private readonly hit: Partial<Hit>;
-  @Input() private readonly highlightedTagName: string = 'mark';
+  @Input() attribute: string;
+  @Input() hit: Partial<Hit>;
+  @Input() highlightedTagName: string = 'mark';
 
   get content() {
     return snippet({


### PR DESCRIPTION
**Summary**

In the previous implementation, inputs for `<ais-snippet>`, `<ais-reverse-highlight>` and `<ais-reverse-snippet>` were wrongly set to `private readonly` which would prevent a user from effectively setting those during implementation.

This PR removes those access modifiers.

**Result**

The widgets can now be used without fail.