### PR TITLE
chore: update peer dependencies range to allow angular 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,9 +151,9 @@
     "zone.js": "0.11.4"
   },
   "peerDependencies": {
-    "@angular/common": ">=5.0.0 <14.0.0",
-    "@angular/core": ">=5.0.0 <14.0.0",
-    "@angular/platform-browser": ">=5.0.0 <14.0.0",
-    "@angular/platform-browser-dynamic": ">=5.0.0 <14.0.0"
+    "@angular/common": ">=5.0.0 <15.0.0",
+    "@angular/core": ">=5.0.0 <15.0.0",
+    "@angular/platform-browser": ">=5.0.0 <15.0.0",
+    "@angular/platform-browser-dynamic": ">=5.0.0 <15.0.0"
   }
 }


### PR DESCRIPTION
**Summary**

This PR updates the range of versions of Angular we are compatible with, to allow users to use Angular InstantSearch with the newly released Angular 14.

I performed an upgrade on a fresh `create-instantsearch-app` template and started the project without issues.

**Result**

Angular 14 is now allowed as a peer dependency of Angular InstantSearch.

Fixes https://github.com/algolia/angular-instantsearch/issues/954