### PR TITLE
fix(searchbox): prevent concurrent query updates from state while input is focused

### DIFF
--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -82,6 +82,11 @@ describe('SearchBox', () => {
         widget.state.query = 'hel';
         fixture.detectChanges();
         expect(searchBox.value).toEqual('hello');
+
+        searchBox.blur();
+        widget.state.query = 'world';
+        fixture.detectChanges();
+        expect(searchBox.value).toEqual('world');
       });
     });
 

--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -63,6 +63,26 @@ describe('SearchBox', () => {
         expect(refine).toHaveBeenCalledTimes(1);
         expect(refine).toHaveBeenCalledWith('the query');
       });
+
+      it('should not update query when out of sync and input is focused', () => {
+        const fixture = createRenderer({
+          defaultState,
+          template: '<ais-search-box></ais-search-box>',
+          TestedWidget: NgAisSearchBox,
+        })();
+        const widget = fixture.componentInstance.testedWidget;
+
+        const searchBox = widget.searchBox.nativeElement;
+        searchBox.focus();
+        searchBox.value = 'hello';
+        searchBox.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+        expect(searchBox.value).toEqual('hello');
+
+        widget.state.query = 'hel';
+        fixture.detectChanges();
+        expect(searchBox.value).toEqual('hello');
+      });
     });
 
     describe('[searchAsYouType]="false"', () => {

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -138,7 +138,9 @@ export class NgAisSearchBox
     // We bypass the state update if the input is focused to avoid concurrent
     // updates when typing.
     if (
-      document.activeElement !== this.searchBox?.nativeElement &&
+      this.searchBox &&
+      this.searchBox.nativeElement &&
+      document.activeElement !== this.searchBox.nativeElement &&
       this.query !== this.state.query
     ) {
       this.query = this.state.query;

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -138,10 +138,10 @@ export class NgAisSearchBox
     // We bypass the state update if the input is focused to avoid concurrent
     // updates when typing.
     if (
+      this.query !== this.state.query &&
       this.searchBox &&
       this.searchBox.nativeElement &&
-      document.activeElement !== this.searchBox.nativeElement &&
-      this.query !== this.state.query
+      document.activeElement !== this.searchBox.nativeElement
     ) {
       this.query = this.state.query;
     }

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -9,6 +9,7 @@ import {
   AfterViewInit,
   ElementRef,
   Optional,
+  DoCheck,
 } from '@angular/core';
 
 import { connectSearchBox } from 'instantsearch.js/es/connectors';
@@ -39,7 +40,7 @@ import {
           role="textbox"
           spellcheck="false"
           type="text"
-          [value]="state.query"
+          [value]="query"
           (input)="handleChange($event.target.value)"
           (focus)="focus.emit($event)"
           (blur)="blur.emit($event)"
@@ -82,7 +83,7 @@ import {
 })
 export class NgAisSearchBox
   extends TypedBaseWidget<SearchBoxWidgetDescription, SearchBoxConnectorParams>
-  implements AfterViewInit {
+  implements AfterViewInit, DoCheck {
   @ViewChild('searchBox', { static: false })
   searchBox: ElementRef;
   @Input() public placeholder: string = 'Search';
@@ -100,6 +101,8 @@ export class NgAisSearchBox
   @Output() change = new EventEmitter();
   @Output() focus = new EventEmitter();
   @Output() blur = new EventEmitter();
+
+  public query = '';
 
   public state: SearchBoxRenderState = {
     query: '',
@@ -128,6 +131,17 @@ export class NgAisSearchBox
   public ngAfterViewInit() {
     if (this.autofocus) {
       this.searchBox.nativeElement.focus();
+    }
+  }
+
+  public ngDoCheck() {
+    // We bypass the state update if the input is focused to avoid concurrent
+    // updates when typing.
+    if (
+      document.activeElement !== this.searchBox?.nativeElement &&
+      this.query !== this.state.query
+    ) {
+      this.query = this.state.query;
     }
   }
 


### PR DESCRIPTION
**Summary**

JIRA: [FX-1590](https://algolia.atlassian.net/browse/FX-1590)

This PR prevents state from overriding the query value in a search box if it still has focus. This can happen in a search-as-you-type environment when network speed is low and a user keeps on typing a query while requests are resolved.
