### PR TITLE
feat(search-box): add loading indicator + `showLoadingIndicator` prop

### DIFF
--- a/src/search-box/__tests__/__snapshots__/search-box.spec.ts.snap
+++ b/src/search-box/__tests__/__snapshots__/search-box.spec.ts.snap
@@ -54,6 +54,47 @@ exports[`SearchBox renders markup with state 1`] = `
               />
             </svg>
           </button>
+          <span
+            class="ais-SearchBox-loadingIndicator"
+            hidden=""
+          >
+            <svg
+              class="ais-SearchBox-loadingIcon"
+              height="16"
+              stroke="#444"
+              viewBox="0 0 38 38"
+              width="16"
+            >
+              <g
+                fill="none"
+                fillRule="evenodd"
+              >
+                <g
+                  strokeWidth="2"
+                  transform="translate(1 1)"
+                >
+                  <circle
+                    cx="18"
+                    cy="18"
+                    r="18"
+                    strokeOpacity=".5"
+                  />
+                  <path
+                    d="M36 18c0-9.94-8.06-18-18-18"
+                  >
+                    <animatetransform
+                      attributeName="transform"
+                      dur="1s"
+                      from="0 18 18"
+                      repeatCount="indefinite"
+                      to="360 18 18"
+                      type="rotate"
+                    />
+                  </path>
+                </g>
+              </g>
+            </svg>
+          </span>
         </form>
       </div>
     </ais-search-box>
@@ -116,6 +157,47 @@ exports[`SearchBox renders markup without state 1`] = `
               />
             </svg>
           </button>
+          <span
+            class="ais-SearchBox-loadingIndicator"
+            hidden=""
+          >
+            <svg
+              class="ais-SearchBox-loadingIcon"
+              height="16"
+              stroke="#444"
+              viewBox="0 0 38 38"
+              width="16"
+            >
+              <g
+                fill="none"
+                fillRule="evenodd"
+              >
+                <g
+                  strokeWidth="2"
+                  transform="translate(1 1)"
+                >
+                  <circle
+                    cx="18"
+                    cy="18"
+                    r="18"
+                    strokeOpacity=".5"
+                  />
+                  <path
+                    d="M36 18c0-9.94-8.06-18-18-18"
+                  >
+                    <animatetransform
+                      attributeName="transform"
+                      dur="1s"
+                      from="0 18 18"
+                      repeatCount="indefinite"
+                      to="360 18 18"
+                      type="rotate"
+                    />
+                  </path>
+                </g>
+              </g>
+            </svg>
+          </span>
         </form>
       </div>
     </ais-search-box>

--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -123,6 +123,41 @@ describe('SearchBox', () => {
     });
   });
 
+  describe('[showLoadingIndicator]', () => {
+    it('should show a loading indicator by default when search is stalled', () => {
+      const fixture = createRenderer({
+        defaultState,
+        template: '<ais-search-box></ais-search-box>',
+        TestedWidget: NgAisSearchBox,
+      })();
+      const widget = fixture.componentInstance.testedWidget;
+      widget.state.isSearchStalled = true;
+      fixture.detectChanges();
+
+      const loadingIndicator = fixture.debugElement.query(
+        By.css('.ais-SearchBox-loadingIndicator')
+      );
+      expect(loadingIndicator.nativeElement.hidden).toBe(false);
+    });
+
+    it('should not show a loading indicator when property is false', () => {
+      const fixture = createRenderer({
+        defaultState,
+        template:
+          '<ais-search-box [showLoadingIndicator]="false"></ais-search-box>',
+        TestedWidget: NgAisSearchBox,
+      })();
+      const widget = fixture.componentInstance.testedWidget;
+      widget.state.isSearchStalled = true;
+      fixture.detectChanges();
+
+      const loadingIndicator = fixture.debugElement.query(
+        By.css('.ais-SearchBox-loadingIndicator')
+      );
+      expect(loadingIndicator.nativeElement.hidden).toBe(true);
+    });
+  });
+
   it('should create a widget that sets the $$widgetType metadata', () => {
     const createWidget = jest.spyOn(NgAisSearchBox.prototype, 'createWidget');
 

--- a/src/search-box/__tests__/search-box.spec.ts
+++ b/src/search-box/__tests__/search-box.spec.ts
@@ -131,6 +131,7 @@ describe('SearchBox', () => {
         TestedWidget: NgAisSearchBox,
       })();
       const widget = fixture.componentInstance.testedWidget;
+      widget.state.query = 'iphone';
       widget.state.isSearchStalled = true;
       fixture.detectChanges();
 
@@ -138,6 +139,23 @@ describe('SearchBox', () => {
         By.css('.ais-SearchBox-loadingIndicator')
       );
       expect(loadingIndicator.nativeElement.hidden).toBe(false);
+    });
+
+    it('should hide reset button by default when search is stalled', () => {
+      const fixture = createRenderer({
+        defaultState,
+        template: '<ais-search-box></ais-search-box>',
+        TestedWidget: NgAisSearchBox,
+      })();
+      const widget = fixture.componentInstance.testedWidget;
+      widget.state.query = 'iphone';
+      widget.state.isSearchStalled = true;
+      fixture.detectChanges();
+
+      const resetButton = fixture.debugElement.query(
+        By.css('.ais-SearchBox-reset')
+      );
+      expect(resetButton.nativeElement.hidden).toBe(true);
     });
 
     it('should not show a loading indicator when property is false', () => {
@@ -148,6 +166,7 @@ describe('SearchBox', () => {
         TestedWidget: NgAisSearchBox,
       })();
       const widget = fixture.componentInstance.testedWidget;
+      widget.state.query = 'iphone';
       widget.state.isSearchStalled = true;
       fixture.detectChanges();
 
@@ -155,6 +174,24 @@ describe('SearchBox', () => {
         By.css('.ais-SearchBox-loadingIndicator')
       );
       expect(loadingIndicator.nativeElement.hidden).toBe(true);
+    });
+
+    it('should not hide reset button when property is false and search is stalled', () => {
+      const fixture = createRenderer({
+        defaultState,
+        template:
+          '<ais-search-box [showLoadingIndicator]="false"></ais-search-box>',
+        TestedWidget: NgAisSearchBox,
+      })();
+      const widget = fixture.componentInstance.testedWidget;
+      widget.state.query = 'iphone';
+      widget.state.isSearchStalled = true;
+      fixture.detectChanges();
+
+      const resetButton = fixture.debugElement.query(
+        By.css('.ais-SearchBox-reset')
+      );
+      expect(resetButton.nativeElement.hidden).toBe(false);
     });
   });
 

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -67,7 +67,7 @@ import {
           type="reset"
           title="{{resetTitle}}"
           (click)="handleReset($event)"
-          [hidden]="!state.query || (state.query && !state.query.trim()) || state.isSearchStalled">
+          [hidden]="!state.query || (state.query && !state.query.trim()) || (state.isSearchStalled && showLoadingIndicator)">
           <svg
             [ngClass]="cx('resetIcon')"
             viewBox="0 0 20 20"

--- a/src/search-box/search-box.ts
+++ b/src/search-box/search-box.ts
@@ -67,7 +67,7 @@ import {
           type="reset"
           title="{{resetTitle}}"
           (click)="handleReset($event)"
-          [hidden]="!state.query || (state.query && !state.query.trim())">
+          [hidden]="!state.query || (state.query && !state.query.trim()) || state.isSearchStalled">
           <svg
             [ngClass]="cx('resetIcon')"
             viewBox="0 0 20 20"
@@ -77,6 +77,35 @@ import {
             <path d="M8.114 10L.944 2.83 0 1.885 1.886 0l.943.943L10 8.113l7.17-7.17.944-.943L20 1.886l-.943.943-7.17 7.17 7.17 7.17.943.944L18.114 20l-.943-.943-7.17-7.17-7.17 7.17-.944.943L0 18.114l.943-.943L8.113 10z"></path>
           </svg>
         </button>
+
+        <span
+          [class]="cx('loadingIndicator')"
+          [hidden]="!showLoadingIndicator || !state.isSearchStalled"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 38 38"
+            stroke="#444"
+            [ngClass]="cx('loadingIcon')"
+          >
+            <g fill="none" fillRule="evenodd">
+              <g transform="translate(1 1)" strokeWidth="2">
+                <circle strokeOpacity=".5" cx="18" cy="18" r="18" />
+                <path d="M36 18c0-9.94-8.06-18-18-18">
+                  <animateTransform
+                    attributeName="transform"
+                    type="rotate"
+                    from="0 18 18"
+                    to="360 18 18"
+                    dur="1s"
+                    repeatCount="indefinite"
+                  />
+                </path>
+              </g>
+            </g>
+          </svg>
+        </span>
       </form>
     </div>
   `,
@@ -91,6 +120,7 @@ export class NgAisSearchBox
   @Input() public resetTitle: string = 'Reset';
   @Input() public searchAsYouType: boolean = true;
   @Input() public autofocus: boolean = false;
+  @Input() public showLoadingIndicator: boolean = true;
 
   // Output events
   // form


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

Work Item : [FX-377](https://algolia.atlassian.net/browse/FX-377)

To stay as close as `InstantSearch.js`'s interface as possible, we decided to add a `showLoadingIndicator` prop which is `true` by default.
The only difference is that we are not able to provide a custom component, which is not feasible for submit/reset buttons anyway.


**Result**

By default, when search is stalled, the reset button will be hidden, and a loading indicator is shown.
If `showLoadingIndicator` is set to false, it will never show a loading indicator, and the reset button will still be present if search is stalled.
