### PR TITLE
feat: support angular 15 through peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,9 +151,9 @@
     "zone.js": "0.11.4"
   },
   "peerDependencies": {
-    "@angular/common": ">=5.0.0 <15.0.0",
-    "@angular/core": ">=5.0.0 <15.0.0",
-    "@angular/platform-browser": ">=5.0.0 <15.0.0",
-    "@angular/platform-browser-dynamic": ">=5.0.0 <15.0.0"
+    "@angular/common": ">=5.0.0 <16.0.0",
+    "@angular/core": ">=5.0.0 <16.0.0",
+    "@angular/platform-browser": ">=5.0.0 <16.0.0",
+    "@angular/platform-browser-dynamic": ">=5.0.0 <16.0.0"
   }
 }


### PR DESCRIPTION
**Summary**

This PR updates the range of versions of Angular we are compatible with, to allow users to use Angular InstantSearch with the newly released Angular 15.

**Result**

Angular 15 is now allowed as a peer dependency of Angular InstantSearch.

