### PR TITLE
ci: use environment variables from context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,14 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - build:
+          context: fx-libraries
+
 jobs:
   build:
     docker:


### PR DESCRIPTION
This PR updates the CircleCI config file so that jobs retrieve relevant environment variables from context. Doing this will allow us to use the same tokens in similar projects.